### PR TITLE
Minor fix to osdctl unarchiving

### DIFF
--- a/pkg/tool/osdctl/osdctl.go
+++ b/pkg/tool/osdctl/osdctl.go
@@ -194,7 +194,7 @@ func unArchive(source string, destination string) error {
 	var f *tar.Header
 	for {
 		f, err = arc.Next()
-		if err != io.EOF {
+		if err == io.EOF {
 			break
 		}
 		if err != nil {


### PR DESCRIPTION
Minor bugfix to the osdctl tooling logic allowing the downloaded tarballs to be unarchived