### PR TITLE
Updated Makefile to utilize goreleaser + golangci-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 bin/
+dist/
 backplane-tools
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,58 @@
-BUILD_DIR:=./bin
+BUILDFLAGS ?=
+unexport GOFLAGS
 
-build: clean
-	mkdir -p ${BUILD_DIR}
-	go build -o "${BUILD_DIR}/backplane-tools" main.go
+BASE_DIR=$(shell pwd)
+BIN_DIR=${BASE_DIR}/bin
 
-clean:
-	rm -rf "${BUILD_DIR}"
+.DEFAULT_GOAL := all
+.PHONY: all
+all: vet fmt mod build test lint
 
+.PHONY: fmt
+fmt:
+	@echo "gofmt"
+	@gofmt -w -s .
+
+OS := $(shell go env GOOS | sed 's/[a-z]/\U&/')
+ARCH := $(shell go env GOARCH)
+
+GORELEASER_VERSION="v1.15.0"
+GOLANGCI_LINT_VERSION="v1.53.3"
+
+.PHONY: download-goreleaser
+download-goreleaser:
+	GOBIN=${BIN_DIR} go install github.com/goreleaser/goreleaser@${GORELEASER_VERSION}
+
+.PHONY: download-golangci-lint
+download-golangci-lint:
+	GOBIN=${BIN_DIR} go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+
+SINGLE_TARGET ?= false
+
+# Need to use --snapshot here because the goReleaser
+# requires more git info that is provided in Prow's clone.
+# Snapshot allows the build without validation of the
+# repository itself
+.PHONY: build
+build: download-goreleaser
+	${BIN_DIR}/goreleaser build --clean --snapshot --id linux_arm64,linux_amd64,darwin_arm64,darwin_amd64 --single-target=${SINGLE_TARGET}
+
+.PHONY: release
+release:
+	${BIN_DIR}/goreleaser release --clean
+
+.PHONY: vet
+vet:
+	go vet ${BUILDFLAGS} ./...
+
+.PHONY: mod
+mod:
+	go mod tidy
+
+.PHONY: test
 test:
-	echo "TODO"
+	go test ${BUILDFLAGS} ./... -covermode=atomic -coverpkg=./...
+
+.PHONY: lint
+lint: download-golangci-lint
+	${BIN_DIR}/golangci-lint run

--- a/pkg/tool/aws-cli/aws-cli.go
+++ b/pkg/tool/aws-cli/aws-cli.go
@@ -60,7 +60,7 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 
 	} else {
 		// Handle unsupported operating systems
-		return fmt.Errorf("Unsupported operating system:", runtime.GOOS)
+		return fmt.Errorf("Unsupported operating system: %s", runtime.GOOS)
 	}
 
 	err = os.RemoveAll(versionedDir)

--- a/pkg/tool/osdctl/osdctl.go
+++ b/pkg/tool/osdctl/osdctl.go
@@ -1,10 +1,7 @@
 package osdctl
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -151,75 +148,6 @@ func (t *Tool) Remove(rootDir, latestDir string) error {
 	return nil
 }
 
-func unArchive(source string, destination string) error {
-	src, err := os.Open(source)
-	if err != nil {
-		return fmt.Errorf("failed to open tarball '%s': %v", source, err)
-	}
-	defer func() {
-		err = src.Close()
-		if err != nil {
-			fmt.Printf("WARNING: failed to close '%s': %v\n", src.Name(), err)
-		}
-	}()
-	uncompressed, err := gzip.NewReader(src)
-	if err != nil {
-		return fmt.Errorf("failed to read the gzip file '%s': %v", source, err)
-	}
-	defer func() {
-		err = uncompressed.Close()
-		if err != nil {
-			fmt.Printf("WARNING: failed to close gzip file '%s': %v", source, err)
-		}
-	}()
-	arc := tar.NewReader(uncompressed)
-	var f *tar.Header
-	for {
-		f, err = arc.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("failed to read from archive '%s': %v", source, err)
-		}
-		if f.FileInfo().IsDir() {
-			err = os.MkdirAll(filepath.Join(destination, f.Name), 0755)
-			if err != nil {
-				return fmt.Errorf("failed to create a directory : %v", err)
-			}
-		} else {
-			err = extractFile(destination, f, arc)
-			if err != nil {
-				return fmt.Errorf("failed to extract files: %v", err)
-			}
-		}
-	}
-	return nil
-}
-
 func (t *Tool) Configure() error {
-	return nil
-}
-
-func extractFile(destination string, f *tar.Header, arc io.Reader) error {
-	dst, err := os.Create(filepath.Join(destination, f.Name))
-	if err != nil {
-		return fmt.Errorf("failed to create file: %v", err)
-	}
-	defer func() {
-		err = dst.Close()
-		if err != nil {
-			fmt.Printf("warning: failed to close '%s': %v\n", dst.Name(), err)
-		}
-	}()
-
-	err = dst.Chmod(os.FileMode(0755))
-	if err != nil {
-		return fmt.Errorf("failed to set permission on '%s': %v", dst.Name(), err)
-	}
-	_, err = dst.ReadFrom(arc)
-	if err != nil {
-		return fmt.Errorf("failed to read from archive  %v", err)
-	}
 	return nil
 }

--- a/pkg/utils/unarchive.go
+++ b/pkg/utils/unarchive.go
@@ -67,7 +67,7 @@ func Unzip(source string, destination string) error {
 	defer func(reader *zip.ReadCloser) {
 		err := reader.Close()
 		if err != nil {
-
+			fmt.Fprintf(os.Stderr, "possible memory leak: failed to close %s", source)
 		}
 	}(reader)
 


### PR DESCRIPTION
Updates the Makefile to utilize  `golangci-lint` as the primary way to lint, and `goreleaser` as the primary means to build and release, backplane-tools.

Credit to https://github.com/openshift/osdctl/blob/master/Makefile for much of the logic in these changes