### PR TITLE
Add 'oc' tool

### DIFF
--- a/pkg/source/openshift/mirror/mirror.go
+++ b/pkg/source/openshift/mirror/mirror.go
@@ -1,0 +1,99 @@
+/*
+mirror provides the capability for tools to retrieve files from mirror.openshift.com
+*/
+package mirror
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+)
+
+const (
+	defaultBaseURL string = "http://mirror.openshift.com"
+)
+
+// Source objects retrieve files from a mirror server
+type Source struct {
+	// baseURL represents the url that the Source's requests should be built off of
+	BaseURL string
+}
+
+// NewSource creates a Source
+func NewSource() *Source {
+	s := &Source{
+		BaseURL: defaultBaseURL,
+	}
+	return s
+}
+
+// downloadFile retrieves the file from the source given the path the file
+// is located at on the server and the local directory the file should be stored in
+func (s Source) DownloadFile(path, dir string) (string, error) {
+	url, err := s.BuildURL(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to build URL: %w", err)
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("failed to GET '%s': %w", url, err)
+	}
+	defer func() {
+		closeErr := resp.Body.Close()
+		if closeErr != nil {
+			fmt.Printf("WARNING: failed to close response body: %v\n", err)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("received non-%d status code: %d", http.StatusOK, resp.StatusCode)
+	}
+
+	_, fileName := filepath.Split(path)
+	filePath := filepath.Join(dir, fileName)
+	file, err := os.Create(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create file '%s': %w", filePath, err)
+	}
+	defer func() {
+		closeErr := file.Close()
+		if closeErr != nil {
+			fmt.Printf("warning: failed to close %s\n", file.Name())
+		}
+	}()
+
+	_, err = file.ReadFrom(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to download the contents of '%s' into '%s': %w", url, file.Name(), err)
+	}
+
+	err = file.Sync()
+	if err != nil {
+		return "", fmt.Errorf("failed to sync contents of '%s' to disk: %w", file.Name(), err)
+	}
+	return file.Name(), nil
+}
+
+// GetFileContents returns the contents of the specified file without storing it locally.
+// It is the callers responsibility to Close() the file after reading
+func (s Source) GetFileContents(path string) (io.ReadCloser, error) {
+	url, err := s.BuildURL(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build URL: %w", err)
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to GET '%s': %w", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received non-%d status code: %d", http.StatusOK, resp.StatusCode)
+	}
+	return resp.Body, nil
+}
+
+// buildURL constructs the full URL the source should operate on given the path of the file we're trying to retrieve
+func (s Source) BuildURL(path string) (string, error) {
+	return url.JoinPath(s.BaseURL, path)
+}

--- a/pkg/tool/oc/oc.go
+++ b/pkg/tool/oc/oc.go
@@ -2,35 +2,193 @@ package oc
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
+
+	openshiftmirror "github.com/openshift/backplane-tools/pkg/source/openshift/mirror"
+	"github.com/openshift/backplane-tools/pkg/utils"
 )
 
-// Tool implements the interface to manage the 'openshift-client' (aka 'oc') binary
-type Tool struct{}
+// Tool implements the interface to manage the 'backplane-cli' binary
+type Tool struct {
+	source *openshiftmirror.Source
+}
 
 func NewTool() *Tool {
-	return &Tool{}
+	t := &Tool{
+		source: openshiftmirror.NewSource(),
+	}
+	return t
 }
 
 func (t *Tool) Name() string {
 	return "oc"
 }
 
-func (t *Tool) Install(rootDir string) error {
-	ocDir := filepath.Join(rootDir, "oc")
-	err := os.Mkdir(ocDir, os.FileMode(0755))
+func (t *Tool) Install(rootDir, latestDir string) error {
+	baseSlug := fmt.Sprintf("/pub/openshift-v4/%s/clients/ocp/stable/", runtime.GOARCH)
+
+	// Retrieve latest release info to determine which version we're operating on
+	ocReleaseSlug := fmt.Sprintf("%s/release.txt", baseSlug)
+	version, err := t.getVersion(ocReleaseSlug)
 	if err != nil {
-		return fmt.Errorf("failed to create install directory for oc: %w", err)
+		return fmt.Errorf("failed to retrieve version info: %w", err)
+	}
+
+	versionedDir := filepath.Join(t.toolDir(rootDir), version)
+	err = os.MkdirAll(versionedDir, os.FileMode(0755))
+	if err != nil {
+		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
+	}
+
+	// Download client archive
+	clientArchiveName := fmt.Sprintf("openshift-client-%s-%s.tar.gz", runtime.GOOS, version)
+	if runtime.GOARCH == "arm64" {
+		clientArchiveName = fmt.Sprintf("openshift-client-%s-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH, version)
+	}
+
+	clientArchiveSlug, err := url.JoinPath(baseSlug, clientArchiveName)
+	if err != nil {
+		return fmt.Errorf("failed to build client URL: %w", err)
+	}
+	clientArchiveFilePath, err := t.source.DownloadFile(clientArchiveSlug, versionedDir)
+	if err != nil {
+		return fmt.Errorf("failed to download client archive file %s: %w", clientArchiveSlug, err)
+	}
+	err = os.Chmod(clientArchiveFilePath, os.FileMode(0755))
+	if err != nil {
+		return fmt.Errorf("failed to update file mode for %s: %w", clientArchiveFilePath, err)
+	}
+
+	// Download latest checksum file
+	checksumSlug, err := url.JoinPath(baseSlug, "sha256sum.txt")
+	if err != nil {
+		return fmt.Errorf("failed to build checksum URL: %w", err)
+	}
+
+	checksumFilePath, err := t.source.DownloadFile(checksumSlug, versionedDir)
+	if err != nil {
+		return fmt.Errorf("failed to download checksum file %s: %w", checksumSlug, err)
+	}
+
+	checksum, err := t.extractChecksumFromFile(checksumFilePath, clientArchiveName)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve checksum from file %s: %w", checksumFilePath, err)
+	}
+
+	// Checksum client archive & compare
+	archiveSum, err := utils.Sha256sum(clientArchiveFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to calculate checksum for '%s': %w", clientArchiveFilePath, err)
+	}
+
+	if strings.TrimSpace(archiveSum) != strings.TrimSpace(checksum) {
+		sourceURL, err := t.source.BuildURL(clientArchiveSlug)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to construct source URL for manual retrieval: %v\n", err)
+			return fmt.Errorf("checksum for %s does not match the calculated value: expected '%s', got '%s'. Please retry installation", clientArchiveFilePath, strings.TrimSpace(checksum), strings.TrimSpace(archiveSum))
+
+		} else {
+			return fmt.Errorf("checksum for %s does not match the calculated value: expected '%s', got '%s'. Please retry installation. If issue persists, this tool can be downloaded manually at %s\n", clientArchiveFilePath, strings.TrimSpace(checksum), strings.TrimSpace(archiveSum), sourceURL)
+		}
+	}
+
+	// Unarchive client
+	err = utils.Unarchive(clientArchiveFilePath, versionedDir)
+	if err != nil {
+		return fmt.Errorf("failed to unarchive %s: %w", clientArchiveFilePath, err)
+	}
+
+	// Link as latest
+	latestFilePath := t.symlinkPath(latestDir)
+	err = os.Remove(latestFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove existing symlink at '%s': %w", latestFilePath, err)
+	}
+
+	clientBinaryFilepath := filepath.Join(versionedDir, "oc")
+	err = os.Symlink(clientBinaryFilepath, latestFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to link %s to %s: %w", clientBinaryFilepath, latestFilePath, err)
 	}
 
 	return nil
 }
 
-func (t *Tool) Configure() error {
+// getVersion retrieves the version info contained within the provided release.txt file
+func (t Tool) getVersion(releaseSlug string) (string, error) {
+	releaseData, err := t.source.GetFileContents(releaseSlug)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve release info from %s: %w", releaseSlug, err)
+	}
+	defer func() {
+		closeErr := releaseData.Close()
+		if closeErr != nil {
+			fmt.Printf("WARNING: failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	line, err := utils.GetLineInReader(releaseData, "Version:")
+	if err != nil {
+		return "", fmt.Errorf("failed to determine version info from release file: %w", err)
+	}
+
+	tokens := strings.Fields(line)
+	if len(tokens) != 2 {
+		return "", fmt.Errorf("failed to parse version info from release: expected 2 tokens, got %d.\nVersion info retrieved:\n%s", len(tokens), line)
+	}
+	if tokens[0] != "Version:" {
+		return "", fmt.Errorf("failed to parse version info from release: expected line to begin with 'Version:', got '%s'.\nVersion info retrieved:\n%s", tokens[0], line)
+	}
+	return tokens[1], nil
+
+}
+
+
+func (t Tool) extractChecksumFromFile(checksumFile, searchPattern string) (string, error) {
+	line, err := utils.GetLineInFile(checksumFile, searchPattern)
+	if err != nil {
+		return "", err
+	}
+
+	tokens := strings.Fields(line)
+	if len(tokens) != 2 {
+		return "", fmt.Errorf("failed to parse checksum info: expected 2 tokens, got %d.\nChecksum info retrieved:\n%s", len(tokens), line)
+	}
+	return tokens[0], nil
+}
+
+// toolDir returns this tool's specific directory given the root directory all tools are installed in
+func (t *Tool) toolDir(rootDir string) string {
+	return filepath.Join(rootDir, "oc")
+}
+
+// symlinkPath returns the path to the symlink created by this tool, given the latest directory
+func (t *Tool) symlinkPath(latestDir string) string {
+	return filepath.Join(latestDir, "oc")
+}
+
+// Remove completely removes this tool from the provided locations
+func (t *Tool) Remove(rootDir, latestDir string) error {
+	// Remove all binaries owned by this tool
+	toolDir := t.toolDir(rootDir)
+	err := os.RemoveAll(toolDir)
+	if err != nil {
+		return fmt.Errorf("failed to remove %s: %w", toolDir, err)
+	}
+
+	// Remove all symlinks owned by this tool
+	latestFilePath := t.symlinkPath(latestDir)
+	err = os.Remove(latestFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to remove symlinked file %s: %w", latestFilePath, err)
+	}
 	return nil
 }
 
-func (t *Tool) Remove() error {
+func (t *Tool) Configure() error {
 	return nil
 }

--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -8,6 +8,7 @@ import (
 
 	awscli "github.com/openshift/backplane-tools/pkg/tool/aws-cli"
 	backplanecli "github.com/openshift/backplane-tools/pkg/tool/backplane-cli"
+	"github.com/openshift/backplane-tools/pkg/tool/oc"
 	"github.com/openshift/backplane-tools/pkg/tool/ocm"
 	"github.com/openshift/backplane-tools/pkg/tool/osdctl"
 	"github.com/openshift/backplane-tools/pkg/tool/rosa"
@@ -37,6 +38,9 @@ func newMap() Map {
 
 	awsTool := awscli.NewTool()
 	toolMap[awsTool.Name()] = awsTool
+
+	ocTool := oc.NewTool()
+	toolMap[ocTool.Name()] = ocTool
 
 	ocmTool := ocm.NewTool()
 	toolMap[ocmTool.Name()] = ocmTool

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -43,12 +44,23 @@ func GetLineInFile(filepath, match string) (res string, err error) {
 			err = closeErr
 		}
 	}()
-	scanner := bufio.NewScanner(file)
+	return GetLineInReader(file, match)
+}
+
+// GetLinInReader searches the provided reader for a line that contains the
+// provided string. If a match is found, the entire line is returned.
+// Only the first result is returned. If no lines match, an error is returned
+func GetLineInReader(reader io.Reader, match string) (res string, err error) {
+	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
+		if scanner.Err() != nil {
+			return "", fmt.Errorf("failed to read line: %w", err)
+		}
 		line := scanner.Text()
+
 		if strings.Contains(line, match) {
 			return line, nil
 		}
 	}
-	return "", fmt.Errorf("failed to find line matching '%s' in '%s'", match, filepath)
+	return "", fmt.Errorf("failed to find matching line for search pattern: '%s'", match)
 }


### PR DESCRIPTION
Adds the tool `oc` to our managed toolset.

This logic downloads the latest stable version of the application from `https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/`, validates it's checksum, unarchives the bundle, and links it to the `latest/` directory.