### PR TITLE
Adds 'list' subcommand family

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ backplane-tools offers an easy solution to install, remove, and upgrade a useful
 - [Tools](#tools)
 - [FAQ - How do I...](#faq-how-do-i)
   - [List available tools](#list-available-tools)
+  - [List installed tools](#list-installed-tools)
+  - [Add the tools I've installed to my $PATH](#add-the-tools-ive-installed-to-my-path)
   - [Install everything](#install-everything)
   - [Install a specific thing](#install-a-specific-thing)
   - [Upgrade everything](#upgrade-everything)
@@ -32,11 +34,15 @@ The tools currently managed by this application include:
 ## FAQ - How do I...
 Quick reference guide
 
-### List available tools for my version of backplane-tools
+### List available tools
 ```shell
-backplane-tools install --help
+backplane-tools list available
 ```
-Tools available for management by backplane-tools are listed under the `Usage` section of the help output within the square brackets (`[]`).
+
+### List installed tools
+```shell
+backplane-tools list installed
+```
 
 ### Add the tools I've installed to my $PATH
 Add the following line to your shell's .rc file:

--- a/cmd/list/available/available.go
+++ b/cmd/list/available/available.go
@@ -1,0 +1,32 @@
+package available
+
+import (
+	"fmt"
+
+	"github.com/openshift/backplane-tools/pkg/tool"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	availableCmd := &cobra.Command{
+		Use: "available",
+		Args: cobra.NoArgs,
+		Aliases: []string{"installable", "possible"},
+		Short: "List available tools for install",
+		Long: "List tools that are available to install with backplane-tools",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return List()
+		},
+	}
+	return availableCmd
+}
+
+func List() error {
+	fmt.Println("The following tools are available for install:")
+
+	toolMap := tool.GetMap()
+	for toolName := range toolMap {
+		fmt.Printf("- %s\n", toolName)
+	}
+	return nil
+}

--- a/cmd/list/installed/installed.go
+++ b/cmd/list/installed/installed.go
@@ -1,0 +1,41 @@
+package installed
+
+import (
+	"fmt"
+
+	"github.com/openshift/backplane-tools/pkg/tool"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	installedCmd := &cobra.Command{
+		Use: "installed",
+		Args: cobra.NoArgs,
+		Short: "List installed tools",
+		Long: "List currently installed tools",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return List()
+		},
+	}
+	return installedCmd
+}
+
+func List() error {
+	toolMap := tool.GetMap()
+	installDir, err := tool.InstallDir()
+	if err != nil {
+		return fmt.Errorf("failed to determine installation directory: %w", err)
+	}
+
+	fmt.Println("Currently installed tools:")
+	for _, t := range toolMap {
+		installed, err := t.Installed(installDir)
+		if err != nil {
+			return fmt.Errorf("failed to determine if '%s' has been installed: %w", t.Name(), err)
+		}
+		if installed {
+			fmt.Printf("- %s\n", t.Name())
+		}
+	}
+	return nil
+}

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -1,0 +1,24 @@
+package list
+
+import (
+	"github.com/openshift/backplane-tools/cmd/list/available"
+	"github.com/openshift/backplane-tools/cmd/list/installed"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	listCmd := &cobra.Command{
+		Use: "list",
+		Args: cobra.NoArgs,
+		Short: "List tools",
+		Long: "List installed & available tools",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+
+	listCmd.AddCommand(available.Cmd())
+	listCmd.AddCommand(installed.Cmd())
+
+	return listCmd
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/openshift/backplane-tools/cmd/install"
+	"github.com/openshift/backplane-tools/cmd/list"
 	"github.com/openshift/backplane-tools/cmd/remove"
 	"github.com/openshift/backplane-tools/cmd/upgrade"
 	"github.com/spf13/cobra"
@@ -23,8 +24,9 @@ func help(cmd *cobra.Command, _ []string) error {
 // Add subcommands
 func init() {
 	cmd.AddCommand(install.Cmd())
-	cmd.AddCommand(upgrade.Cmd())
+	cmd.AddCommand(list.Cmd())
 	cmd.AddCommand(remove.Cmd())
+	cmd.AddCommand(upgrade.Cmd())
 }
 
 func main() {

--- a/pkg/tool/aws-cli/aws-cli.go
+++ b/pkg/tool/aws-cli/aws-cli.go
@@ -127,6 +127,11 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	return nil
 }
 
+func (t *Tool) Installed(rootDir string) (bool, error) {
+	toolDir := t.toolDir(rootDir)
+	return utils.FileExists(toolDir)
+}
+
 // toolDir returns this tool's specific directory given the root directory all tools are installed in
 func (t *Tool) toolDir(rootDir string) string {
 	return filepath.Join(rootDir, "aws")

--- a/pkg/tool/backplane-cli/backplane-cli.go
+++ b/pkg/tool/backplane-cli/backplane-cli.go
@@ -128,6 +128,11 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	return nil
 }
 
+func (t *Tool) Installed(rootDir string) (bool, error) {
+	toolDir := t.toolDir(rootDir)
+	return utils.FileExists(toolDir)
+}
+
 // toolDir returns this tool's specific directory given the root directory all tools are installed in
 func (t *Tool) toolDir(rootDir string) string {
 	return filepath.Join(rootDir, "backplane-cli")

--- a/pkg/tool/oc/oc.go
+++ b/pkg/tool/oc/oc.go
@@ -118,6 +118,11 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	return nil
 }
 
+func (t *Tool) Installed(rootDir string) (bool, error) {
+	toolDir := t.toolDir(rootDir)
+	return utils.FileExists(toolDir)
+}
+
 // getVersion retrieves the version info contained within the provided release.txt file
 func (t Tool) getVersion(releaseSlug string) (string, error) {
 	releaseData, err := t.source.GetFileContents(releaseSlug)

--- a/pkg/tool/ocm/ocm.go
+++ b/pkg/tool/ocm/ocm.go
@@ -10,6 +10,7 @@ import (
 
 	gogithub "github.com/google/go-github/v51/github"
 	"github.com/openshift/backplane-tools/pkg/source/github"
+	"github.com/openshift/backplane-tools/pkg/utils"
 )
 
 // Tool implements the interface to manage the 'ocm-cli' binary
@@ -112,6 +113,11 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 		return fmt.Errorf("failed to link new 'ocm' binary to '%s': %w", latestDir, err)
 	}
 	return nil
+}
+
+func (t *Tool) Installed(rootDir string) (bool, error) {
+	toolDir := t.toolDir(rootDir)
+	return utils.FileExists(toolDir)
 }
 
 // toolDir returns this tool's specific directory given the root directory all tools are installed in

--- a/pkg/tool/osdctl/osdctl.go
+++ b/pkg/tool/osdctl/osdctl.go
@@ -122,6 +122,11 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	return nil
 }
 
+func (t Tool) Installed(rootDir string) (bool, error) {
+	toolDir := t.toolDir(rootDir)
+	return utils.FileExists(toolDir)
+}
+
 // toolDir returns this tool's specific directory given the root directory all tools are installed in
 func (t *Tool) toolDir(rootDir string) string {
 	return filepath.Join(rootDir, "osdctl")

--- a/pkg/tool/rosa/rosa.go
+++ b/pkg/tool/rosa/rosa.go
@@ -117,6 +117,11 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	return nil
 }
 
+func (t *Tool) Installed(rootDir string) (bool, error) {
+	toolDir := t.toolDir(rootDir)
+	return utils.FileExists(toolDir)
+}
+
 // toolDir returns this tool's specific directory given the root directory all tools are installed in
 func (t *Tool) toolDir(rootDir string) string {
 	return filepath.Join(rootDir, "rosa")

--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -16,13 +16,24 @@ import (
 )
 
 type Tool interface {
+	// Name returns the name of the tool
 	Name() string
 
+	// Install fetches the latest tool from it's respective source, installs
+	// it in a tool-unique directory under the provided rootDir, and symlinks
+	// it to provided the latestDir
 	Install(rootDir, latestDir string) error
 
+	// Confiure is currently unused
 	Configure() error
 
+	// Remove uninstalls the tool by deleting it's tool-unique directory under
+	// the provided rootDir and unlinking itself from the latestDir
 	Remove(rootDir, latestDir string) error
+
+	// Installed validates whether the tool has already been installed under the
+	// provided rootDir or not
+	Installed(rootDir string) (bool, error)
 }
 
 type Map map[string]Tool

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -28,6 +28,18 @@ func Keys[T, U comparable](myMap map[T]U) []T {
 	return keys
 }
 
+// FileExists checks if a file *of any type* is present at the given path
+func FileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // GetLineInFile searches the provided file for a line that contains the
 // provided string. If a match is found, the entire line is returned.
 // Only the first result is returned. If no lines match, an error is returned


### PR DESCRIPTION
These changes add a `list` subcommand family with two subcommands:
- `backplane-tools list available` returns a list of tools which are available to install with the current `backplane-tools` binary
- `backplane-tools list installed` returns the list of tools which have already been installed to the local filesystem