### PR TITLE
Upgrade only previously installed tools. Minor refactor to Upgrade() for better portability

### DIFF
--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -193,3 +193,24 @@ func RemoveInstallDir() error {
 	}
 	return os.RemoveAll(installDir)
 }
+
+// ListInstalled returns a slice containing all tools the current machine has installed
+func ListInstalled() ([]Tool, error) {
+	tools := GetMap()
+	installedTools := []Tool{}
+	installDir, err := InstallDir()
+	if err != nil {
+		return installedTools, err
+	}
+
+	for _, tool := range tools {
+		installed, err := tool.Installed(installDir)
+		if err != nil {
+			return installedTools, err
+		}
+		if installed {
+			installedTools = append(installedTools, tool)
+		}
+	}
+	return installedTools, nil
+}


### PR DESCRIPTION
Reorganizes upgrade logic to take advantage of the new `Installed()` method introduced in https://github.com/openshift/backplane-tools/pull/15 to only upgrade tools that have been previously installed by backplane-tools. This allows users to opt-out of upgrading specific tools, which is key for maintaining a stable environment.

These changes also improve the portability of the `Upgrade()` function by eliminating the requirement for calling logic to pass in `cobra.Command` and `tool.Map` objects.