### PR TITLE
Installing aws, sould also expose aws_composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ backplane-tools offers an easy solution to install, remove, and upgrade a useful
 ## Tools
 The tools currently managed by this application include:
 
-* aws
+* aws (including aws_completer)
 * backplane-cli
 * ocm
 * osdctl

--- a/cmd/list/available/available.go
+++ b/cmd/list/available/available.go
@@ -9,11 +9,11 @@ import (
 
 func Cmd() *cobra.Command {
 	availableCmd := &cobra.Command{
-		Use: "available",
-		Args: cobra.NoArgs,
+		Use:     "available",
+		Args:    cobra.NoArgs,
 		Aliases: []string{"installable", "possible"},
-		Short: "List available tools for install",
-		Long: "List tools that are available to install with backplane-tools",
+		Short:   "List available tools for install",
+		Long:    "List tools that are available to install with backplane-tools",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return List()
 		},

--- a/cmd/list/installed/installed.go
+++ b/cmd/list/installed/installed.go
@@ -9,10 +9,10 @@ import (
 
 func Cmd() *cobra.Command {
 	installedCmd := &cobra.Command{
-		Use: "installed",
-		Args: cobra.NoArgs,
+		Use:   "installed",
+		Args:  cobra.NoArgs,
 		Short: "List installed tools",
-		Long: "List currently installed tools",
+		Long:  "List currently installed tools",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return List()
 		},

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -8,10 +8,10 @@ import (
 
 func Cmd() *cobra.Command {
 	listCmd := &cobra.Command{
-		Use: "list",
-		Args: cobra.NoArgs,
+		Use:   "list",
+		Args:  cobra.NoArgs,
 		Short: "List tools",
-		Long: "List installed & available tools",
+		Long:  "List installed & available tools",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -38,7 +38,6 @@ func Cmd() *cobra.Command {
 	return upgradeCmd
 }
 
-
 // Upgrade upgrades the provided tools to their latest versions
 func Upgrade(tools []string) error {
 	toolMap := tool.GetMap()

--- a/pkg/tool/backplane-cli/backplane-cli.go
+++ b/pkg/tool/backplane-cli/backplane-cli.go
@@ -99,7 +99,7 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	}
 	checksumTokens := strings.Fields(checksumLine)
 	if len(checksumTokens) != 2 {
-			return fmt.Errorf("the checksum file '%s' is invalid: expected 2 fields, got %d", checksumFilePath, len(checksumTokens))
+		return fmt.Errorf("the checksum file '%s' is invalid: expected 2 fields, got %d", checksumFilePath, len(checksumTokens))
 	}
 	actual := checksumTokens[0]
 

--- a/pkg/tool/oc/oc.go
+++ b/pkg/tool/oc/oc.go
@@ -152,7 +152,6 @@ func (t Tool) getVersion(releaseSlug string) (string, error) {
 
 }
 
-
 func (t Tool) extractChecksumFromFile(checksumFile, searchPattern string) (string, error) {
 	line, err := utils.GetLineInFile(checksumFile, searchPattern)
 	if err != nil {

--- a/pkg/tool/rosa/rosa.go
+++ b/pkg/tool/rosa/rosa.go
@@ -95,7 +95,7 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	}
 	checksumTokens := strings.Fields(checksumLine)
 	if len(checksumTokens) != 2 {
-			return fmt.Errorf("the checksum file '%s' is invalid: expected 2 fields, got %d", checksumFilePath, len(checksumTokens))
+		return fmt.Errorf("the checksum file '%s' is invalid: expected 2 fields, got %d", checksumFilePath, len(checksumTokens))
 	}
 	actual := checksumTokens[0]
 

--- a/pkg/tool/self/self.go
+++ b/pkg/tool/self/self.go
@@ -95,7 +95,7 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	}
 	checksumTokens := strings.Fields(checksumLine)
 	if len(checksumTokens) != 2 {
-			return fmt.Errorf("the checksum file '%s' is invalid: expected 2 fields, got %d", checksumFilePath, len(checksumTokens))
+		return fmt.Errorf("the checksum file '%s' is invalid: expected 2 fields, got %d", checksumFilePath, len(checksumTokens))
 	}
 	actual := checksumTokens[0]
 

--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -8,11 +8,11 @@ import (
 
 	awscli "github.com/openshift/backplane-tools/pkg/tool/aws-cli"
 	backplanecli "github.com/openshift/backplane-tools/pkg/tool/backplane-cli"
-	"github.com/openshift/backplane-tools/pkg/tool/self"
 	"github.com/openshift/backplane-tools/pkg/tool/oc"
 	"github.com/openshift/backplane-tools/pkg/tool/ocm"
 	"github.com/openshift/backplane-tools/pkg/tool/osdctl"
 	"github.com/openshift/backplane-tools/pkg/tool/rosa"
+	"github.com/openshift/backplane-tools/pkg/tool/self"
 	"github.com/openshift/backplane-tools/pkg/tool/yq"
 	"github.com/openshift/backplane-tools/pkg/utils"
 )

--- a/pkg/tool/yq/yq.go
+++ b/pkg/tool/yq/yq.go
@@ -23,7 +23,7 @@ type Tool struct {
 func NewTool() *Tool {
 	t := &Tool{
 		source: github.NewSource("mikefarah", "yq"),
-		name: "yq",
+		name:   "yq",
 	}
 	return t
 }
@@ -87,7 +87,7 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	}
 
 	// Verify checksum of downloaded assets
-	binaryFilepath:= filepath.Join(versionedDir, binaryAsset.GetName())
+	binaryFilepath := filepath.Join(versionedDir, binaryAsset.GetName())
 	binarySum, err := utils.Sha256sum(binaryFilepath)
 	if err != nil {
 		return fmt.Errorf("failed to calculate checksum for '%s': %w", binaryFilepath, err)


### PR DESCRIPTION
aws does not provide completion command, and instead we need to use the aws_completor binary which is provided on the side of aws binary. When backplane-tools install aws, it then need to create the symlink in latest folder for that binary also