### PR TITLE
make sure checksum key isn't part of bigger one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BIN_DIR=${BASE_DIR}/bin
 
 .DEFAULT_GOAL := all
 .PHONY: all
-all: vet fmt mod build test lint
+all: vet fmt mod lint test build
 
 .PHONY: fmt
 fmt:

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
 	golang.org/x/net v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=

--- a/pkg/tool/backplane-cli/backplane-cli.go
+++ b/pkg/tool/backplane-cli/backplane-cli.go
@@ -93,7 +93,7 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	}
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFile(checksumFilePath, backplaneArchiveAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, backplaneArchiveAsset.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}

--- a/pkg/tool/oc/oc.go
+++ b/pkg/tool/oc/oc.go
@@ -150,7 +150,7 @@ func (t Tool) getVersion(releaseSlug string) (string, error) {
 }
 
 func (t Tool) extractChecksumFromFile(checksumFile, searchPattern string) (string, error) {
-	line, err := utils.GetLineInFile(checksumFile, searchPattern)
+	line, err := utils.GetLineInFileMatchingKey(checksumFile, searchPattern)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/tool/osdctl/osdctl.go
+++ b/pkg/tool/osdctl/osdctl.go
@@ -89,7 +89,7 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	}
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFile(checksumFilePath, osdctlBinaryAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, osdctlBinaryAsset.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}

--- a/pkg/tool/rosa/rosa.go
+++ b/pkg/tool/rosa/rosa.go
@@ -89,7 +89,7 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	}
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFile(checksumFilePath, rosaBinaryAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, rosaBinaryAsset.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}

--- a/pkg/tool/self/self.go
+++ b/pkg/tool/self/self.go
@@ -89,7 +89,7 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	}
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFile(checksumFilePath, backplaneArchiveAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, backplaneArchiveAsset.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}

--- a/pkg/tool/yq/yq.go
+++ b/pkg/tool/yq/yq.go
@@ -95,7 +95,7 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 	}
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFile(checksumFilePath, binaryAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, binaryAsset.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 )
 
@@ -40,10 +41,12 @@ func FileExists(path string) (bool, error) {
 	return true, nil
 }
 
-// GetLineInFile searches the provided file for a line that contains the
-// provided string. If a match is found, the entire line is returned.
+// GetLineInFileMatchingKey searches the provided file for a line that contains the
+// provided key. A key is a pattern that will be either at the begin/end of line and
+// will have ::spaces:: characters around.
+// If a match is found, the entire line is returned.
 // Only the first result is returned. If no lines match, an error is returned
-func GetLineInFile(filepath, match string) (res string, err error) {
+func GetLineInFileMatchingKey(filepath string, key string) (res string, err error) {
 	file, err := os.Open(filepath)
 	if err != nil {
 		return "", err
@@ -56,7 +59,25 @@ func GetLineInFile(filepath, match string) (res string, err error) {
 			err = closeErr
 		}
 	}()
-	return GetLineInReader(file, match)
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		r, err := regexp.Compile("(^|\\s)" + key + "($|\\s)")
+		if err != nil {
+			return "", err
+		}
+		match := r.FindStringSubmatch(line)
+		if len(match) > 0 {
+			return line, nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return "", fmt.Errorf("no match found")
 }
 
 // GetLinInReader searches the provided reader for a line that contains the

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -60,21 +60,22 @@ func GetLineInFileMatchingKey(filepath string, key string) (res string, err erro
 		}
 	}()
 
+	r, err := regexp.Compile("(^|\\s)" + key + "($|\\s)")
+	if err != nil {
+		return "", err
+	}
+
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
+		if scanner.Err() != nil {  
+            return "", fmt.Errorf("failed to read line: %w", err)  
+        }  
 		line := scanner.Text()
-		r, err := regexp.Compile("(^|\\s)" + key + "($|\\s)")
-		if err != nil {
-			return "", err
-		}
+
 		match := r.FindStringSubmatch(line)
 		if len(match) > 0 {
 			return line, nil
 		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return "", err
 	}
 
 	return "", fmt.Errorf("no match found")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -67,9 +67,9 @@ func GetLineInFileMatchingKey(filepath string, key string) (res string, err erro
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		if scanner.Err() != nil {  
-            return "", fmt.Errorf("failed to read line: %w", err)  
-        }  
+		if scanner.Err() != nil {
+			return "", fmt.Errorf("failed to read line: %w", err)
+		}
 		line := scanner.Text()
 
 		match := r.FindStringSubmatch(line)


### PR DESCRIPTION
Some checksum files (like for yq) contain many checksums.
In that case, the checksum "key" we are looking at (eg: yq_linux_amd64) may be found as being part of another key (eg: yq_linux_amd64.tar.gz), depending on the order in that file.
To avoid that, when we look for the key, we can make sure that before the key it is either the beginning of the line or a ::space:: character, and after the key it is either the end of line or a ::space:: character.
This is required for yq, looking at checksum file structure, but I did the change for all tools for consistency and to avoid any future issue.