### PR TITLE
HOTFIX: override the OS name for 'darwin' runtimes

### DIFF
--- a/pkg/tool/oc/oc.go
+++ b/pkg/tool/oc/oc.go
@@ -46,8 +46,9 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 
 	// Download client archive
 	clientArchiveName := fmt.Sprintf("openshift-client-%s-%s.tar.gz", runtime.GOOS, version)
-	if runtime.GOARCH == "arm64" {
-		clientArchiveName = fmt.Sprintf("openshift-client-%s-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH, version)
+	if runtime.GOOS == "darwin" {
+		// 'darwin' OSes are referred to as 'mac' in mirror.openshift.com
+		clientArchiveName = fmt.Sprintf("openshift-client-mac-%s.tar.gz", version)
 	}
 
 	clientArchiveSlug, err := url.JoinPath(baseSlug, clientArchiveName)


### PR DESCRIPTION
Forces the use of `mac` instead of `darwin` when downloading oc's archive from mirror.openshift.com.

Also omits `os.GOARCH` from the client archive name, since it only seems to introduce complexity into the logic with little added benefit
