### PR TITLE
HOTFIX: Reference 'x86_64' instead of 'amd64' when self-upgrading

### DIFF
--- a/pkg/tool/self/self.go
+++ b/pkg/tool/self/self.go
@@ -35,6 +35,11 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 		return err
 	}
 
+	arch := runtime.GOARCH
+	if arch == "amd64" {
+		arch = "x86_64"
+	}
+
 	// Determine which assets to download
 	var checksumAsset *gogithub.ReleaseAsset
 	var backplaneArchiveAsset *gogithub.ReleaseAsset
@@ -47,7 +52,7 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 			continue
 		}
 		// Exclude assets that do not match system architecture
-		if !strings.Contains(asset.GetName(), runtime.GOARCH) {
+		if !strings.Contains(asset.GetName(), arch) {
 			continue
 		}
 		// Exclude assets that do not match system OS


### PR DESCRIPTION
Updates the `self` package's installation logic to use `x86_64` as the architecture identifier instead of `amd64`, following #34 