### PR TITLE
Revert "HOTFIX: Reference 'x86_64' instead of 'amd64' when self-upgrading"

### DIFF
--- a/pkg/tool/self/self.go
+++ b/pkg/tool/self/self.go
@@ -35,11 +35,6 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 		return err
 	}
 
-	arch := runtime.GOARCH
-	if arch == "amd64" {
-		arch = "x86_64"
-	}
-
 	// Determine which assets to download
 	var checksumAsset *gogithub.ReleaseAsset
 	var backplaneArchiveAsset *gogithub.ReleaseAsset
@@ -52,7 +47,7 @@ func (t *Tool) Install(rootDir, latestDir string) error {
 			continue
 		}
 		// Exclude assets that do not match system architecture
-		if !strings.Contains(asset.GetName(), arch) {
+		if !strings.Contains(asset.GetName(), runtime.GOARCH) {
 			continue
 		}
 		// Exclude assets that do not match system OS


### PR DESCRIPTION
Reverts openshift/backplane-tools#37