### PR TITLE
Simplify asset selection logic

### DIFF
--- a/pkg/tools/backplanecli/backplanecli.go
+++ b/pkg/tools/backplanecli/backplanecli.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	gogithub "github.com/google/go-github/v51/github"
@@ -36,42 +35,17 @@ func (t *Tool) Install() error {
 		return err
 	}
 
-	// Determine which assets to download
-	var checksumAsset *gogithub.ReleaseAsset
-	var backplaneArchiveAsset *gogithub.ReleaseAsset
-	arch := runtime.GOARCH
-	if arch == "amd64" {
-		arch = "x86_64"
+	matches := github.FindAssetsForArchAndOS(release.Assets)
+	if len(matches) != 1 {
+		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	for _, asset := range release.Assets {
-		if asset.GetName() == "checksums.txt" {
-			if checksumAsset.GetName() != "" {
-				return fmt.Errorf("detected duplicate backplane-cli checksum assets")
-			}
-			checksumAsset = asset
-			continue
-		}
-		// Exclude assets that do not match system architecture
-		if !strings.Contains(asset.GetName(), arch) {
-			continue
-		}
-		// Exclude assets that do not match system OS
-		if !strings.Contains(strings.ToLower(asset.GetName()), strings.ToLower(runtime.GOOS)) {
-			continue
-		}
+	backplaneArchiveAsset := matches[0]
 
-		if backplaneArchiveAsset.GetName() != "" {
-			return fmt.Errorf("detected duplicate backplane-cli binary assets")
-		}
-		backplaneArchiveAsset = asset
+	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
+	if len(matches) != 1 {
+		return fmt.Errorf("unexpected number of checksum assets found: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	// Ensure both checksum and binary were retrieved
-	if backplaneArchiveAsset.GetName() == "" {
-		return fmt.Errorf("failed to find valid backplane-cli binary asset")
-	}
-	if checksumAsset.GetName() == "" {
-		return fmt.Errorf("failed to find valid backplane-cli checksum asset")
-	}
+	checksumAsset := matches[0]
 
 	// Download the arch- & os-specific assets
 	toolDir := t.ToolDir()

--- a/pkg/tools/self/self.go
+++ b/pkg/tools/self/self.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	gogithub "github.com/google/go-github/v51/github"
@@ -35,38 +34,17 @@ func (t *Tool) Install() error {
 		return err
 	}
 
-	// Determine which assets to download
-	var checksumAsset *gogithub.ReleaseAsset
-	var backplaneArchiveAsset *gogithub.ReleaseAsset
-	for _, asset := range release.Assets {
-		if strings.Contains(asset.GetName(), "checksums.txt") {
-			if checksumAsset.GetName() != "" {
-				return fmt.Errorf("detected duplicate backplane-tools checksum assets")
-			}
-			checksumAsset = asset
-			continue
-		}
-		// Exclude assets that do not match system architecture
-		if !strings.Contains(asset.GetName(), runtime.GOARCH) {
-			continue
-		}
-		// Exclude assets that do not match system OS
-		if !strings.Contains(strings.ToLower(asset.GetName()), strings.ToLower(runtime.GOOS)) {
-			continue
-		}
+	matches := github.FindAssetsForArchAndOS(release.Assets)
+	if len(matches) != 1 {
+		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
+	}
+	backplaneArchiveAsset := matches[0]
 
-		if backplaneArchiveAsset.GetName() != "" {
-			return fmt.Errorf("detected duplicate backplane-tools binary assets")
-		}
-		backplaneArchiveAsset = asset
+	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
+	if len(matches) != 1 {
+		return fmt.Errorf("unexpected number of checksum assets found: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	// Ensure both checksum and binary were retrieved
-	if backplaneArchiveAsset.GetName() == "" {
-		return fmt.Errorf("failed to find valid backplane-tools binary asset")
-	}
-	if checksumAsset.GetName() == "" {
-		return fmt.Errorf("failed to find valid backplane-tools checksum asset")
-	}
+	checksumAsset := matches[0]
 
 	// Download the arch- & os-specific assets
 	toolDir := t.ToolDir()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,6 +19,26 @@ func Contains[T comparable](list []T, val T) bool {
 	return false
 }
 
+// ContainsAll returns true if all of the provided search terms are a substring of 'str'
+func ContainsAll(str string, terms []string) bool {
+	for _, term := range terms {
+		if !strings.Contains(str, term) {
+			return false
+		}
+	}
+	return true
+}
+
+// ContainsAny returns true if any of the provided search terms are a substring of 'str'
+func ContainsAny(str string, terms []string) bool {
+	for _, term := range terms {
+		if strings.Contains(str, term) {
+			return true
+		}
+	}
+	return false
+}
+
 // Keys returns a slice containing the keys of the provided map.
 // Order is preserved
 func Keys[T, U comparable](myMap map[T]U) []T {


### PR DESCRIPTION
Adds logic to simplify the asset selection process for github-based tools. 

These changes establish a set of functions to find the correct release assets for the local system. Using these functions both improves consistency between the tools and provides a level of "error correction" by searching for commonly-used alternatives to the current runtime's `GOARCH` and `GOOS` 