### PR TITLE
Adds arch switch for linux for container runtime support

### DIFF
--- a/pkg/tools/awscli/awscli.go
+++ b/pkg/tools/awscli/awscli.go
@@ -51,10 +51,14 @@ func (t *Tool) Install() error {
 
 	switch runtime.GOOS {
 	case "linux":
+		arch := "x86_64"
+		if runtime.GOARCH == "arm64" {
+			arch = "aarch64"
+		}
 		// Assign variables for Linux
 		awsExecDir = "dist"
 		fileExtension = ".zip"
-		url = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-" + version + fileExtension
+		url = "https://awscli.amazonaws.com/awscli-exe-linux-" + arch + "-" + version + fileExtension
 	case "darwin":
 		// Assign variables for macOS
 		awsExecDir = "aws-cli.pkg/Payload/aws-cli"


### PR DESCRIPTION
When attempting to use backplane-tools within ocm-container on an arm Macbook it would throw an error about not being able to find a `lib-x86_64.so` file when trying to validate the aws install because of the hardcoded architecture.

This puts the architecture selection within a switch inside of the OS switch statement in order to be able to install the correct arm binary within linux.

This should also help support any future arm-based linux builds, not just ocm-container on macs.