### PR TITLE
add ocm-addons utility

### DIFF
--- a/pkg/tools/ocmaddons/ocmaddons.go
+++ b/pkg/tools/ocmaddons/ocmaddons.go
@@ -1,0 +1,104 @@
+package ocmaddons
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gogithub "github.com/google/go-github/v51/github"
+	"github.com/openshift/backplane-tools/pkg/sources/github"
+	"github.com/openshift/backplane-tools/pkg/tools/base"
+	"github.com/openshift/backplane-tools/pkg/utils"
+)
+
+// Tool implements the interface to manage the 'ocm-addons' binary
+type Tool struct {
+	base.Github
+}
+
+func New() *Tool {
+	t := &Tool{
+		Github: base.Github{
+			Default: base.NewDefaultWithExecutable("ocm-addons", "ocm-addons"),
+			Source:  github.NewSource("mt-sre", "ocm-addons"),
+		},
+	}
+	return t
+}
+
+func (t *Tool) Install() error {
+	// Pull latest release from GH
+	release, err := t.Source.FetchLatestRelease()
+	if err != nil {
+		return err
+	}
+
+	matches := github.FindAssetsForArchAndOS(release.Assets)
+	if len(matches) != 1 {
+		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
+	}
+	ocmaddonsArchiveAsset := matches[0]
+
+	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
+	if len(matches) != 1 {
+		return fmt.Errorf("unexpected number of checksum assets found: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
+	}
+	checksumAsset := matches[0]
+
+	// Download the arch- & os-specific assets
+	toolDir := t.ToolDir()
+	versionedDir := filepath.Join(toolDir, release.GetTagName())
+	err = os.MkdirAll(versionedDir, os.FileMode(0o755))
+	if err != nil {
+		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
+	}
+
+	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, ocmaddonsArchiveAsset}, versionedDir)
+	if err != nil {
+		return fmt.Errorf("failed to download one or more assets: %w", err)
+	}
+
+	// Verify checksum of downloaded assets
+	ocmaddonsArchiveFilepath := filepath.Join(versionedDir, ocmaddonsArchiveAsset.GetName())
+	binarySum, err := utils.Sha256sum(ocmaddonsArchiveFilepath)
+	if err != nil {
+		return fmt.Errorf("failed to calculate checksum for '%s': %w", ocmaddonsArchiveFilepath, err)
+	}
+
+	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, ocmaddonsArchiveAsset.GetName())
+	if err != nil {
+		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
+	}
+	checksumTokens := strings.Fields(checksumLine)
+	if len(checksumTokens) != 2 {
+		return fmt.Errorf("the checksum file '%s' is invalid: expected 2 fields, got %d", checksumFilePath, len(checksumTokens))
+	}
+	actual := checksumTokens[0]
+
+	toolExecutable := t.ExecutableName()
+	if strings.TrimSpace(binarySum) != strings.TrimSpace(actual) {
+		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", toolExecutable, ocmaddonsArchiveAsset.GetBrowserDownloadURL())
+	}
+
+	// Untar binary bundle
+	err = utils.Unarchive(ocmaddonsArchiveFilepath, versionedDir)
+	if err != nil {
+		return fmt.Errorf("failed to unarchive the '%s' asset file '%s': %w", toolExecutable, ocmaddonsArchiveFilepath, err)
+	}
+
+	// Link as latest
+	latestFilePath := t.SymlinkPath()
+	err = os.Remove(latestFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove existing '%s' binary at '%s': %w", toolExecutable, base.LatestDir, err)
+	}
+
+	toolBinaryFilepath := filepath.Join(versionedDir, toolExecutable)
+	err = os.Symlink(toolBinaryFilepath, latestFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to link new '%s' binary to '%s': %w", toolExecutable, base.LatestDir, err)
+	}
+	return nil
+}

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/backplane-tools/pkg/tools/gcloud"
 	"github.com/openshift/backplane-tools/pkg/tools/oc"
 	"github.com/openshift/backplane-tools/pkg/tools/ocm"
+	"github.com/openshift/backplane-tools/pkg/tools/ocmaddons"
 	"github.com/openshift/backplane-tools/pkg/tools/osdctl"
 	"github.com/openshift/backplane-tools/pkg/tools/rosa"
 	"github.com/openshift/backplane-tools/pkg/tools/self"
@@ -67,6 +68,9 @@ func initMap() {
 
 	ocm := ocm.New()
 	toolMap[ocm.Name()] = ocm
+
+	ocmaddons := ocmaddons.New()
+	toolMap[ocmaddons.Name()] = ocmaddons
 
 	osdctl := osdctl.New()
 	toolMap[osdctl.Name()] = osdctl


### PR DESCRIPTION
adds ocm-addons utility used to query ocm for cluster addons

```
 $ ocm addons cluster info e384570f-bdff-42... --no-color


    ID                               | EXTERNAL_ID                          | NAME         | ORGANIZATION_ID             | PRODUCT_ID | INSTALLED_ADDONS   | DNS_BASE_DOMAIN
    29chpfks35c... | e384570f-bdff-4225-9dd... | ai... | 1pwwsfazToamNe...| rosa       | managed-odh(ready) | qic7.p1.openshiftapps.com
```


test:
```
$  ./dist/backplane-tools_linux_amd64_v1/backplane-tools list available
The following tools are available for install:
- aws 2.15.20
- osdctl v0.25.0
- backplane-cli v0.1.23
- rosa v1.2.34
- yq v4.40.7
- butane v0.19.0
- backplane-tools v0.4.1
- oc 4.14.11
- ocm v0.1.72
- ocm-addons v0.7.16
- gcloud google-cloud-cli-464.0.0-linux-x86_64
[tomas@ugnis backplane-tools]$  ./dist/backplane-tools_linux_amd64_v1/backplane-tools install ocm-addons
Installing the following tools:
- ocm-addons v0.7.16

Installing ocm-addons
Successfully installed ocm-addons

WARNING: Detected that '/home/tomas/.local/bin/backplane/latest' is not present in $PATH: it's recommended '/home/tomas/.local/bin/backplane/latest' is added to your $PATH to utilize the tools provided by this application
```