### PR TITLE
common boilerplate for go tools using github source

### DIFF
--- a/pkg/tools/backplanecli/backplanecli.go
+++ b/pkg/tools/backplanecli/backplanecli.go
@@ -38,7 +38,7 @@ func (t *Tool) Install() error {
 	if len(matches) != 1 {
 		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	backplaneArchiveAsset := matches[0]
+	toolArchiveAsset := matches[0]
 
 	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
 	if len(matches) != 1 {
@@ -54,20 +54,20 @@ func (t *Tool) Install() error {
 		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
 	}
 
-	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, backplaneArchiveAsset}, versionedDir)
+	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, toolArchiveAsset}, versionedDir)
 	if err != nil {
 		return fmt.Errorf("failed to download one or more assets: %w", err)
 	}
 
 	// Verify checksum of downloaded assets
-	backplaneArchiveFilepath := filepath.Join(versionedDir, backplaneArchiveAsset.GetName())
-	binarySum, err := utils.Sha256sum(backplaneArchiveFilepath)
+	toolArchiveFilepath := filepath.Join(versionedDir, toolArchiveAsset.GetName())
+	binarySum, err := utils.Sha256sum(toolArchiveFilepath)
 	if err != nil {
-		return fmt.Errorf("failed to calculate checksum for '%s': %w", backplaneArchiveFilepath, err)
+		return fmt.Errorf("failed to calculate checksum for '%s': %w", toolArchiveFilepath, err)
 	}
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, backplaneArchiveAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, toolArchiveAsset.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}
@@ -77,27 +77,28 @@ func (t *Tool) Install() error {
 	}
 	actual := checksumTokens[0]
 
+	toolExecutable := t.ExecutableName()
 	if strings.TrimSpace(binarySum) != strings.TrimSpace(actual) {
-		return fmt.Errorf("warning: Checksum for backplane-cli does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", backplaneArchiveAsset.GetBrowserDownloadURL())
+		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", toolExecutable, toolArchiveAsset.GetBrowserDownloadURL())
 	}
 
 	// Untar binary bundle
-	err = utils.Unarchive(backplaneArchiveFilepath, versionedDir)
+	err = utils.Unarchive(toolArchiveFilepath, versionedDir)
 	if err != nil {
-		return fmt.Errorf("failed to unarchive the osdctl asset file '%s': %w", backplaneArchiveFilepath, err)
+		return fmt.Errorf("failed to unarchive the '%s' asset file '%s': %w", toolExecutable, toolArchiveFilepath, err)
 	}
 
 	// Link as latest
 	latestFilePath := t.SymlinkPath()
 	err = os.Remove(latestFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove existing 'ocm-backplane' binary at '%s': %w", base.LatestDir, err)
+		return fmt.Errorf("failed to remove existing '%s' binary at '%s': %w", toolExecutable, base.LatestDir, err)
 	}
 
-	backplaneBinaryFilepath := filepath.Join(versionedDir, "ocm-backplane")
-	err = os.Symlink(backplaneBinaryFilepath, latestFilePath)
+	toolBinaryFilepath := filepath.Join(versionedDir, toolExecutable)
+	err = os.Symlink(toolBinaryFilepath, latestFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to link new 'ocm-backplane' binary to '%s': %w", base.LatestDir, err)
+		return fmt.Errorf("failed to link new '%s' binary to '%s': %w", toolExecutable, base.LatestDir, err)
 	}
 	return nil
 }

--- a/pkg/tools/ocm/ocm.go
+++ b/pkg/tools/ocm/ocm.go
@@ -1,8 +1,6 @@
 package ocm
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +9,7 @@ import (
 	gogithub "github.com/google/go-github/v51/github"
 	"github.com/openshift/backplane-tools/pkg/sources/github"
 	"github.com/openshift/backplane-tools/pkg/tools/base"
+	"github.com/openshift/backplane-tools/pkg/utils"
 )
 
 // Tool implements the interface to manage the 'ocm-cli' binary
@@ -36,17 +35,16 @@ func (t *Tool) Install() error {
 	}
 
 	matches := github.FindAssetsForArchAndOS(release.Assets)
-	binaryMatches := github.FindAssetsExcluding([]string{"sha256"}, matches)
-	if len(binaryMatches) != 1 {
+	if len(matches) != 1 {
 		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	ocmBinaryAsset := binaryMatches[0]
+	toolArchiveAsset := matches[0]
 
-	checksumMatches := github.FindAssetsContaining([]string{"sha256"}, matches)
-	if len(checksumMatches) != 1 {
+	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
+	if len(matches) != 1 {
 		return fmt.Errorf("unexpected number of checksum assets found: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	checksumAsset := checksumMatches[0]
+	checksumAsset := matches[0]
 
 	// Download the arch- & os-specific assets
 	toolDir := t.ToolDir()
@@ -56,42 +54,51 @@ func (t *Tool) Install() error {
 		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
 	}
 
-	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, ocmBinaryAsset}, versionedDir)
+	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, toolArchiveAsset}, versionedDir)
 	if err != nil {
 		return fmt.Errorf("failed to download one or more assets: %w", err)
 	}
 
 	// Verify checksum of downloaded assets
-	ocmBinaryFilepath := filepath.Join(versionedDir, ocmBinaryAsset.GetName())
-	fileBytes, err := os.ReadFile(ocmBinaryFilepath)
+	toolArchiveFilepath := filepath.Join(versionedDir, toolArchiveAsset.GetName())
+	binarySum, err := utils.Sha256sum(toolArchiveFilepath)
 	if err != nil {
-		return fmt.Errorf("failed to read ocm-cli binary file '%s' while generating sha256sum: %w", ocmBinaryFilepath, err)
+		return fmt.Errorf("failed to calculate checksum for '%s': %w", toolArchiveFilepath, err)
 	}
-	sumBytes := sha256.Sum256(fileBytes)
-	binarySum := hex.EncodeToString(sumBytes[:])
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumBytes, err := os.ReadFile(checksumFilePath)
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, toolArchiveAsset.GetName())
 	if err != nil {
-		return fmt.Errorf("failed to read ocm-cli checksum file '%s': %w", checksumFilePath, err)
+		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}
-	checksum := strings.Split(string(checksumBytes), " ")[0]
-	if strings.TrimSpace(binarySum) != strings.TrimSpace(checksum) {
-		fmt.Printf("WARNING: Checksum for ocm-cli does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s\n", ocmBinaryAsset.GetBrowserDownloadURL())
-		// We shouldn't link this binary to latest if the checksum isn't valid
-		return nil
+	checksumTokens := strings.Fields(checksumLine)
+	if len(checksumTokens) != 2 {
+		return fmt.Errorf("the checksum file '%s' is invalid: expected 2 fields, got %d", checksumFilePath, len(checksumTokens))
+	}
+	actual := checksumTokens[0]
+
+	toolExecutable := t.ExecutableName()
+	if strings.TrimSpace(binarySum) != strings.TrimSpace(actual) {
+		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", toolExecutable, toolArchiveAsset.GetBrowserDownloadURL())
+	}
+
+	// Untar binary bundle
+	err = utils.Unarchive(toolArchiveFilepath, versionedDir)
+	if err != nil {
+		return fmt.Errorf("failed to unarchive the '%s' asset file '%s': %w", toolExecutable, toolArchiveFilepath, err)
 	}
 
 	// Link as latest
 	latestFilePath := t.SymlinkPath()
 	err = os.Remove(latestFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove existing 'ocm' binary at '%s': %w", base.LatestDir, err)
+		return fmt.Errorf("failed to remove existing '%s' binary at '%s': %w", toolExecutable, base.LatestDir, err)
 	}
 
-	err = os.Symlink(ocmBinaryFilepath, latestFilePath)
+	toolBinaryFilepath := filepath.Join(versionedDir, toolExecutable)
+	err = os.Symlink(toolBinaryFilepath, latestFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to link new 'ocm' binary to '%s': %w", base.LatestDir, err)
+		return fmt.Errorf("failed to link new '%s' binary to '%s': %w", toolExecutable, base.LatestDir, err)
 	}
 	return nil
 }

--- a/pkg/tools/ocmaddons/ocmaddons.go
+++ b/pkg/tools/ocmaddons/ocmaddons.go
@@ -38,7 +38,7 @@ func (t *Tool) Install() error {
 	if len(matches) != 1 {
 		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	ocmaddonsArchiveAsset := matches[0]
+	toolArchiveAsset := matches[0]
 
 	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
 	if len(matches) != 1 {
@@ -54,20 +54,20 @@ func (t *Tool) Install() error {
 		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
 	}
 
-	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, ocmaddonsArchiveAsset}, versionedDir)
+	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, toolArchiveAsset}, versionedDir)
 	if err != nil {
 		return fmt.Errorf("failed to download one or more assets: %w", err)
 	}
 
 	// Verify checksum of downloaded assets
-	ocmaddonsArchiveFilepath := filepath.Join(versionedDir, ocmaddonsArchiveAsset.GetName())
-	binarySum, err := utils.Sha256sum(ocmaddonsArchiveFilepath)
+	toolArchiveFilepath := filepath.Join(versionedDir, toolArchiveAsset.GetName())
+	binarySum, err := utils.Sha256sum(toolArchiveFilepath)
 	if err != nil {
-		return fmt.Errorf("failed to calculate checksum for '%s': %w", ocmaddonsArchiveFilepath, err)
+		return fmt.Errorf("failed to calculate checksum for '%s': %w", toolArchiveFilepath, err)
 	}
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, ocmaddonsArchiveAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, toolArchiveAsset.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}
@@ -79,13 +79,13 @@ func (t *Tool) Install() error {
 
 	toolExecutable := t.ExecutableName()
 	if strings.TrimSpace(binarySum) != strings.TrimSpace(actual) {
-		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", toolExecutable, ocmaddonsArchiveAsset.GetBrowserDownloadURL())
+		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", toolExecutable, toolArchiveAsset.GetBrowserDownloadURL())
 	}
 
 	// Untar binary bundle
-	err = utils.Unarchive(ocmaddonsArchiveFilepath, versionedDir)
+	err = utils.Unarchive(toolArchiveFilepath, versionedDir)
 	if err != nil {
-		return fmt.Errorf("failed to unarchive the '%s' asset file '%s': %w", toolExecutable, ocmaddonsArchiveFilepath, err)
+		return fmt.Errorf("failed to unarchive the '%s' asset file '%s': %w", toolExecutable, toolArchiveFilepath, err)
 	}
 
 	// Link as latest

--- a/pkg/tools/osdctl/osdctl.go
+++ b/pkg/tools/osdctl/osdctl.go
@@ -39,9 +39,9 @@ func (t *Tool) Install() error {
 	if len(matches) != 1 {
 		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	osdctlBinaryAsset := matches[0]
+	toolArchiveAsset := matches[0]
 
-	matches = github.FindAssetsContaining([]string{"sha256sum.txt"}, release.Assets)
+	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
 	if len(matches) != 1 {
 		return fmt.Errorf("unexpected number of checksum assets found: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
@@ -55,20 +55,20 @@ func (t *Tool) Install() error {
 		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
 	}
 
-	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, osdctlBinaryAsset}, versionedDir)
+	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, toolArchiveAsset}, versionedDir)
 	if err != nil {
 		return fmt.Errorf("failed to download one or more assets: %w", err)
 	}
 
 	// Verify checksum of downloaded assets
-	osdctlBinaryFilepath := filepath.Join(versionedDir, osdctlBinaryAsset.GetName())
-	binarySum, err := utils.Sha256sum(osdctlBinaryFilepath)
+	toolArchiveFilepath := filepath.Join(versionedDir, toolArchiveAsset.GetName())
+	binarySum, err := utils.Sha256sum(toolArchiveFilepath)
 	if err != nil {
-		return fmt.Errorf("failed to calculate checksum for '%s': %w", osdctlBinaryFilepath, err)
+		return fmt.Errorf("failed to calculate checksum for '%s': %w", toolArchiveFilepath, err)
 	}
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, osdctlBinaryAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, toolArchiveAsset.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}
@@ -78,25 +78,28 @@ func (t *Tool) Install() error {
 	}
 	actual := checksumTokens[0]
 
+	toolExecutable := t.ExecutableName()
 	if strings.TrimSpace(binarySum) != strings.TrimSpace(actual) {
-		return fmt.Errorf("warning: Checksum for osdctl does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", osdctlBinaryAsset.GetBrowserDownloadURL())
+		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", toolExecutable, toolArchiveAsset.GetBrowserDownloadURL())
 	}
 
-	// Untar osdctl file
-	err = utils.Unarchive(osdctlBinaryFilepath, versionedDir)
+	// Untar binary bundle
+	err = utils.Unarchive(toolArchiveFilepath, versionedDir)
 	if err != nil {
-		return fmt.Errorf("failed to unarchive the osdctl asset file '%s': %w", osdctlBinaryFilepath, err)
+		return fmt.Errorf("failed to unarchive the '%s' asset file '%s': %w", toolExecutable, toolArchiveFilepath, err)
 	}
 
 	// Link as latest
 	latestFilePath := t.SymlinkPath()
 	err = os.Remove(latestFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove existing 'osdctl' binary at '%s': %w", base.LatestDir, err)
+		return fmt.Errorf("failed to remove existing '%s' binary at '%s': %w", toolExecutable, base.LatestDir, err)
 	}
-	err = os.Symlink(filepath.Join(versionedDir, "osdctl"), latestFilePath)
+
+	toolBinaryFilepath := filepath.Join(versionedDir, toolExecutable)
+	err = os.Symlink(toolBinaryFilepath, latestFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to link new 'osdctl' binary to '%s': %w", base.LatestDir, err)
+		return fmt.Errorf("failed to link new '%s' binary to '%s': %w", toolExecutable, base.LatestDir, err)
 	}
 	return nil
 }

--- a/pkg/tools/self/self.go
+++ b/pkg/tools/self/self.go
@@ -38,7 +38,7 @@ func (t *Tool) Install() error {
 	if len(matches) != 1 {
 		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	backplaneArchiveAsset := matches[0]
+	toolArchiveAsset := matches[0]
 
 	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
 	if len(matches) != 1 {
@@ -54,20 +54,20 @@ func (t *Tool) Install() error {
 		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
 	}
 
-	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, backplaneArchiveAsset}, versionedDir)
+	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, toolArchiveAsset}, versionedDir)
 	if err != nil {
 		return fmt.Errorf("failed to download one or more assets: %w", err)
 	}
 
 	// Verify checksum of downloaded assets
-	backplaneArchiveFilepath := filepath.Join(versionedDir, backplaneArchiveAsset.GetName())
-	binarySum, err := utils.Sha256sum(backplaneArchiveFilepath)
+	toolArchiveFilepath := filepath.Join(versionedDir, toolArchiveAsset.GetName())
+	binarySum, err := utils.Sha256sum(toolArchiveFilepath)
 	if err != nil {
-		return fmt.Errorf("failed to calculate checksum for '%s': %w", backplaneArchiveFilepath, err)
+		return fmt.Errorf("failed to calculate checksum for '%s': %w", toolArchiveFilepath, err)
 	}
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, backplaneArchiveAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, toolArchiveAsset.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}
@@ -77,27 +77,28 @@ func (t *Tool) Install() error {
 	}
 	actual := checksumTokens[0]
 
+	toolExecutable := t.ExecutableName()
 	if strings.TrimSpace(binarySum) != strings.TrimSpace(actual) {
-		return fmt.Errorf("warning: Checksum for backplane-tools does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", backplaneArchiveAsset.GetBrowserDownloadURL())
+		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", toolExecutable, toolArchiveAsset.GetBrowserDownloadURL())
 	}
 
 	// Untar binary bundle
-	err = utils.Unarchive(backplaneArchiveFilepath, versionedDir)
+	err = utils.Unarchive(toolArchiveFilepath, versionedDir)
 	if err != nil {
-		return fmt.Errorf("failed to unarchive the backplane-tools asset file '%s': %w", backplaneArchiveFilepath, err)
+		return fmt.Errorf("failed to unarchive the '%s' asset file '%s': %w", toolExecutable, toolArchiveFilepath, err)
 	}
 
 	// Link as latest
 	latestFilePath := t.SymlinkPath()
 	err = os.Remove(latestFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove existing 'backplane-tools' binary at '%s': %w", base.LatestDir, err)
+		return fmt.Errorf("failed to remove existing '%s' binary at '%s': %w", toolExecutable, base.LatestDir, err)
 	}
 
-	backplaneBinaryFilepath := filepath.Join(versionedDir, "backplane-tools")
-	err = os.Symlink(backplaneBinaryFilepath, latestFilePath)
+	toolBinaryFilepath := filepath.Join(versionedDir, toolExecutable)
+	err = os.Symlink(toolBinaryFilepath, latestFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to link new 'backplane-tools' binary to '%s': %w", base.LatestDir, err)
+		return fmt.Errorf("failed to link new '%s' binary to '%s': %w", toolExecutable, base.LatestDir, err)
 	}
 	return nil
 }

--- a/pkg/tools/yq/yq.go
+++ b/pkg/tools/yq/yq.go
@@ -35,16 +35,13 @@ func (t *Tool) Install() error {
 		return err
 	}
 
-	matches := github.FindAssetsExcluding([]string{".tar.gz"}, github.FindAssetsForArchAndOS(release.Assets))
+	matches := github.FindAssetsForArchAndOS(release.Assets)
 	if len(matches) != 1 {
 		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	binaryAsset := matches[0]
+	toolArchiveAsset := matches[0]
 
-	matches, err = github.FindAssetsMatching("^checksums$", release.Assets)
-	if err != nil {
-		return fmt.Errorf("failed to find checksum asset: %w", err)
-	}
+	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
 	if len(matches) != 1 {
 		return fmt.Errorf("unexpected number of checksum assets found: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
@@ -58,39 +55,51 @@ func (t *Tool) Install() error {
 		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
 	}
 
-	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, binaryAsset}, versionedDir)
+	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, toolArchiveAsset}, versionedDir)
 	if err != nil {
 		return fmt.Errorf("failed to download one or more assets: %w", err)
 	}
 
 	// Verify checksum of downloaded assets
-	binaryFilepath := filepath.Join(versionedDir, binaryAsset.GetName())
-	binarySum, err := utils.Sha256sum(binaryFilepath)
+	toolArchiveFilepath := filepath.Join(versionedDir, toolArchiveAsset.GetName())
+	binarySum, err := utils.Sha256sum(toolArchiveFilepath)
 	if err != nil {
-		return fmt.Errorf("failed to calculate checksum for '%s': %w", binaryFilepath, err)
+		return fmt.Errorf("failed to calculate checksum for '%s': %w", toolArchiveFilepath, err)
 	}
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, binaryAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, toolArchiveAsset.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}
+	checksumTokens := strings.Fields(checksumLine)
+	if len(checksumTokens) != 2 {
+		return fmt.Errorf("the checksum file '%s' is invalid: expected 2 fields, got %d", checksumFilePath, len(checksumTokens))
+	}
+	actual := checksumTokens[0]
 
-	// For some reason, yq ships several checksum formats for each asset in its 'checksums' file.
-	// Its honestly less fragile to check if _any_ of the columns contain our calculated checksum than try to decipher which column corresponds to which format
-	if !strings.Contains(checksumLine, strings.TrimSpace(binarySum)) {
-		return fmt.Errorf("warning: Checksum for yq does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", binaryAsset.GetBrowserDownloadURL())
+	toolExecutable := t.ExecutableName()
+	if strings.TrimSpace(binarySum) != strings.TrimSpace(actual) {
+		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", toolExecutable, toolArchiveAsset.GetBrowserDownloadURL())
+	}
+
+	// Untar binary bundle
+	err = utils.Unarchive(toolArchiveFilepath, versionedDir)
+	if err != nil {
+		return fmt.Errorf("failed to unarchive the '%s' asset file '%s': %w", toolExecutable, toolArchiveFilepath, err)
 	}
 
 	// Link as latest
 	latestFilePath := t.SymlinkPath()
 	err = os.Remove(latestFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove existing 'yq' binary at '%s': %w", base.LatestDir, err)
+		return fmt.Errorf("failed to remove existing '%s' binary at '%s': %w", toolExecutable, base.LatestDir, err)
 	}
-	err = os.Symlink(filepath.Join(versionedDir, binaryAsset.GetName()), latestFilePath)
+
+	toolBinaryFilepath := filepath.Join(versionedDir, toolExecutable)
+	err = os.Symlink(toolBinaryFilepath, latestFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to link new 'yq' binary to '%s': %w", base.LatestDir, err)
+		return fmt.Errorf("failed to link new '%s' binary to '%s': %w", toolExecutable, base.LatestDir, err)
 	}
 	return nil
 }


### PR DESCRIPTION
use same install process for go (goreleased?) tools on github

```
 ./dist/backplane-tools_linux_amd64_v1/backplane-tools list available
The following tools are available for install:
- aws 2.15.20
- backplane-cli v0.1.23
- rosa v1.2.34
- yq v4.41.1
- butane v0.19.0
- backplane-tools v0.4.1
- oc 4.14.11
- ocm v0.1.72
- ocm-addons v0.7.16
- osdctl v0.25.0
- gcloud google-cloud-cli-464.0.0-linux-x86_64
```