### PR TITLE
Fix rosa install to use new asset structure

### DIFF
--- a/pkg/tools/rosa/rosa.go
+++ b/pkg/tools/rosa/rosa.go
@@ -34,15 +34,15 @@ func (t *Tool) Install() error {
 		return err
 	}
 
-	matches := github.FindAssetsForArchAndOS(release.Assets)
+	matches := github.FindAssetsExcluding([]string{".sha256"}, github.FindAssetsForArchAndOS(release.Assets))
 	if len(matches) != 1 {
 		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	toolArchiveAsset := matches[0]
+	toolAsset := matches[0]
 
-	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
+	matches = github.FindAssetsContaining([]string{".sha256"}, github.FindAssetsForArchAndOS(release.Assets))
 	if len(matches) != 1 {
-		return fmt.Errorf("unexpected number of checksum assets found: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
+		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
 	checksumAsset := matches[0]
 
@@ -54,20 +54,20 @@ func (t *Tool) Install() error {
 		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
 	}
 
-	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, toolArchiveAsset}, versionedDir)
+	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, toolAsset}, versionedDir)
 	if err != nil {
 		return fmt.Errorf("failed to download one or more assets: %w", err)
 	}
 
 	// Verify checksum of downloaded assets
-	toolArchiveFilepath := filepath.Join(versionedDir, toolArchiveAsset.GetName())
+	toolArchiveFilepath := filepath.Join(versionedDir, toolAsset.GetName())
 	binarySum, err := utils.Sha256sum(toolArchiveFilepath)
 	if err != nil {
 		return fmt.Errorf("failed to calculate checksum for '%s': %w", toolArchiveFilepath, err)
 	}
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, toolArchiveAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, toolAsset.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}
@@ -77,28 +77,21 @@ func (t *Tool) Install() error {
 	}
 	actual := checksumTokens[0]
 
-	toolExecutable := t.ExecutableName()
 	if strings.TrimSpace(binarySum) != strings.TrimSpace(actual) {
-		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", toolExecutable, toolArchiveAsset.GetBrowserDownloadURL())
-	}
-
-	// Untar binary bundle
-	err = utils.Unarchive(toolArchiveFilepath, versionedDir)
-	if err != nil {
-		return fmt.Errorf("failed to unarchive the '%s' asset file '%s': %w", toolExecutable, toolArchiveFilepath, err)
+		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", *toolAsset.Name, toolAsset.GetBrowserDownloadURL())
 	}
 
 	// Link as latest
 	latestFilePath := t.SymlinkPath()
 	err = os.Remove(latestFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove existing '%s' binary at '%s': %w", toolExecutable, base.LatestDir, err)
+		return fmt.Errorf("failed to remove existing '%s' binary at '%s': %w", *toolAsset.Name, base.LatestDir, err)
 	}
 
-	toolBinaryFilepath := filepath.Join(versionedDir, toolExecutable)
+	toolBinaryFilepath := filepath.Join(versionedDir, *toolAsset.Name)
 	err = os.Symlink(toolBinaryFilepath, latestFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to link new '%s' binary to '%s': %w", toolExecutable, base.LatestDir, err)
+		return fmt.Errorf("failed to link new '%s' binary to '%s': %w", *toolAsset.Name, base.LatestDir, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Re-implements `backplane-tools install rosa` to account for new installation assets.