### PR TITLE
Update osdctl checksum asset name

### DIFF
--- a/pkg/tools/osdctl/osdctl.go
+++ b/pkg/tools/osdctl/osdctl.go
@@ -13,6 +13,10 @@ import (
 	"github.com/openshift/backplane-tools/pkg/utils"
 )
 
+const (
+	toolChecksumAssetName = "sha256sum.txt"
+)
+
 // Tool implements the interface to manage the 'osdctl' binary
 type Tool struct {
 	base.Github
@@ -41,7 +45,7 @@ func (t *Tool) Install() error {
 	}
 	toolArchiveAsset := matches[0]
 
-	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
+	matches = github.FindAssetsContaining([]string{toolChecksumAssetName}, release.Assets)
 	if len(matches) != 1 {
 		return fmt.Errorf("unexpected number of checksum assets found: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}


### PR DESCRIPTION
Corrects the checksum asset name for the osdctl tool from `checksums.txt` to `sha256sum.txt`. 

Adds this name as a constant at the top of the osdctl tool definition for easier discoverability in the future.