### PR TITLE
Fix ocm installation

### DIFF
--- a/pkg/tools/ocm/ocm.go
+++ b/pkg/tools/ocm/ocm.go
@@ -35,16 +35,17 @@ func (t *Tool) Install() error {
 	}
 
 	matches := github.FindAssetsForArchAndOS(release.Assets)
-	if len(matches) != 1 {
+	toolMatches := github.FindAssetsExcluding([]string{"sha256"}, matches)
+	if len(toolMatches) != 1 {
 		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	toolArchiveAsset := matches[0]
+	toolAsset := toolMatches[0]
 
-	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
-	if len(matches) != 1 {
+	checksumMatches := github.FindAssetsContaining([]string{"sha256"}, matches)
+	if len(checksumMatches) != 1 {
 		return fmt.Errorf("unexpected number of checksum assets found: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}
-	checksumAsset := matches[0]
+	checksumAsset := checksumMatches[0]
 
 	// Download the arch- & os-specific assets
 	toolDir := t.ToolDir()
@@ -54,20 +55,20 @@ func (t *Tool) Install() error {
 		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
 	}
 
-	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, toolArchiveAsset}, versionedDir)
+	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, toolAsset}, versionedDir)
 	if err != nil {
 		return fmt.Errorf("failed to download one or more assets: %w", err)
 	}
 
 	// Verify checksum of downloaded assets
-	toolArchiveFilepath := filepath.Join(versionedDir, toolArchiveAsset.GetName())
+	toolArchiveFilepath := filepath.Join(versionedDir, toolAsset.GetName())
 	binarySum, err := utils.Sha256sum(toolArchiveFilepath)
 	if err != nil {
 		return fmt.Errorf("failed to calculate checksum for '%s': %w", toolArchiveFilepath, err)
 	}
 
 	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, toolArchiveAsset.GetName())
+	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, toolAsset.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
 	}
@@ -77,28 +78,21 @@ func (t *Tool) Install() error {
 	}
 	actual := checksumTokens[0]
 
-	toolExecutable := t.ExecutableName()
 	if strings.TrimSpace(binarySum) != strings.TrimSpace(actual) {
-		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", toolExecutable, toolArchiveAsset.GetBrowserDownloadURL())
-	}
-
-	// Untar binary bundle
-	err = utils.Unarchive(toolArchiveFilepath, versionedDir)
-	if err != nil {
-		return fmt.Errorf("failed to unarchive the '%s' asset file '%s': %w", toolExecutable, toolArchiveFilepath, err)
+		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", toolAsset.GetName(), toolAsset.GetBrowserDownloadURL())
 	}
 
 	// Link as latest
 	latestFilePath := t.SymlinkPath()
 	err = os.Remove(latestFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove existing '%s' binary at '%s': %w", toolExecutable, base.LatestDir, err)
+		return fmt.Errorf("failed to remove existing '%s' binary at '%s': %w", toolAsset.GetName(), base.LatestDir, err)
 	}
 
-	toolBinaryFilepath := filepath.Join(versionedDir, toolExecutable)
+	toolBinaryFilepath := filepath.Join(versionedDir, toolAsset.GetName())
 	err = os.Symlink(toolBinaryFilepath, latestFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to link new '%s' binary to '%s': %w", toolExecutable, base.LatestDir, err)
+		return fmt.Errorf("failed to link new '%s' binary to '%s': %w", toolAsset.GetName(), base.LatestDir, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Reverts some changes from https://github.com/openshift/backplane-tools/pull/49 that broke `ocm` installation