### PR TITLE
Add the ci-operator config for prow into the repo

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,5 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: rhel-8-release-golang-1.20-openshift-4.14


### PR DESCRIPTION
Pushing the existing config from openshift/release so we can update the go version in-repo