### PR TITLE
Updates the error message for installing tools

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -43,7 +43,7 @@ func Install(args []string) error {
 	for _, tool := range installList {
 		latestversion, err := tool.LatestVersion()
 		if err != nil {
-			return fmt.Errorf("Unable to get latest version of %s: %w", tool.Name(), err)
+			return fmt.Errorf("unable to get latest version of %s: %w", tool.Name(), err)
 		}
 		fmt.Printf("- %s %s\n", tool.Name(), latestversion)
 	}

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -43,7 +43,7 @@ func Install(args []string) error {
 	for _, tool := range installList {
 		latestversion, err := tool.LatestVersion()
 		if err != nil {
-			return err
+			return fmt.Errorf("Unable to get latest version of %s: %w", tool.Name(), err)
 		}
 		fmt.Printf("- %s %s\n", tool.Name(), latestversion)
 	}


### PR DESCRIPTION
Adds a better error output for this step, changing from:
```
Installing the following tools:
- servicelogger v0.1.1
- aws 2.15.34
- oc 4.15.3
- butane v0.20.0
Error: failed to locate latest archive matching system spec: unexpected number of assets found matching system spec: expected at least 1, got 0
```

to

```
Installing the following tools:
- servicelogger v0.1.1
- aws 2.15.34
- oc 4.15.3
- butane v0.20.0
Error: unable to install the latest version of osdctl: failed to locate latest archive matching system spec: unexpected number of assets found matching system spec: expected at least 1, got 0
```

This way you can at least see as the end user if it's the same package that's failing to install.