### PR TITLE
Add string "github.com" to token lookup

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -27,7 +27,7 @@ type Source struct {
 }
 
 func NewSource(owner, repo string) *Source {
-	token, _ := auth.TokenForHost("")
+	token, _ := auth.TokenForHost("github.com")
 	var tc *http.Client
 	if token != "" {
 		ctx := context.Background()


### PR DESCRIPTION
The function `auth.TokenForHost()` assumes a string argument to properly identify the token lookup method for the host.  Due to a bug(?) in the auth package, if an empty string is provided, it ends up looking for GitHub Enterprise credentials, and returns an empty token if it doesn't find them.  Since we're assuming the token is provided either in the `gh` config or the `GH_TOKEN` env, when it is using the latter, calls to GitHub are not authenticated.

This PR uses "github.com" as the string for `auth.TokenForHost()`, to ensure credentials (including `GH_TOKEN`) are properly retrieved from the environment.

I have confirmed this to work with a container image build testing `backplane-tools install all`, and checking the rate limit, `x-ratelimit-used` has only incremented by one (which is the call to check the limit itself) after a full backplane-tools install run.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
