### PR TITLE
Update arch aliases for Mac ARM series

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -149,10 +149,13 @@ func WriteFile(from io.Reader, to string, permissions os.FileMode) error {
 
 // GetArchAliases returns all commonly used names for the system's architecture.
 // ie - An 'amd64' system is functionally equivalent to 'x86_64' for our purposes
+// An 'arm64' system is functionally equivalent to 'arm' for our purposes (mainly gcloud)
 func GetArchAliases() []string {
 	switch runtime.GOARCH {
 	case "amd64":
 		return []string{"amd64", "x86_64"}
+	case "arm64":
+		return []string{"arm64", "arm"}
 	default:
 		return []string{runtime.GOARCH}
 	}


### PR DESCRIPTION
This PR adds arch aliases - `arm64` & `arm` for ARM64. This is because some binaries like gcloud do not have `arm64` in the binary name, which was causing issues for installation.

Relevant discussion - https://redhat-internal.slack.com/archives/C04PUGBE7JN/p1716351644144979

Before the change
```
❯ backplane-tools install gcloud
Installing the following tools:
Error: failed to locate latest archive matching system spec: unexpected number of assets found matching system spec: expected at least 1, got 0
Usage:
  backplane-tools install [all|backplane-tools|oc|rosa|yq|butane|servicelogger|aws|ocm|ocm-addons|osdctl|backplane-cli|gcloud] [flags]

Flags:
  -h, --help   help for install

2024/05/22 10:35:49 Error executing command: failed to locate latest archive matching system spec: unexpected number of assets found matching system spec: expected at least 1, got 0
```


After the change
```
❯ ./backplane-tools install gcloud               
Installing the following tools:
- gcloud google-cloud-cli-477.0.0-darwin-arm

Installing gcloud
Successfully installed gcloud
```