### PR TITLE
fixes yq for linux arm64

### DIFF
--- a/pkg/tools/yq/yq.go
+++ b/pkg/tools/yq/yq.go
@@ -36,6 +36,12 @@ func (t *Tool) Install() error {
 	}
 
 	matches := github.FindAssetsExcluding([]string{".tar.gz"}, github.FindAssetsForArchAndOS(release.Assets))
+	if len(matches) == 2 {
+		// yq provides both a linux-arm and linux-arm64 binary. This may apply to any other arch, so lets
+		// just generally prefer a match on the 64 bit version if it is available, otherwise
+		// we just pass through the failure
+		matches = github.FindAssetsContaining([]string{"64"}, matches)
+	}
 	if len(matches) != 1 {
 		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
 	}


### PR DESCRIPTION
[yq](https://github.com/mikefarah/yq/releases/tag/v4.47.1) releases both `linux-arm` and `linux-arm64` binaries.

If we match more than one binary, prefer the 64-bit version. If that doesn't return only a single binary then the existing error logic will kick in.

Tested this by putting the new backplane-tools binary into ocm-container's container builder and validated that yq did install successfully after.

Fixes https://issues.redhat.com/browse/SREP-1737