### PR TITLE
Add cleanup subcommand to remove older tool versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Quick reference guide
 Install backplane-tools with the following command:
 
 ```shell
-go install github.com/openshift/backplane-tools@latest; backplane-tools install all```
+go install github.com/openshift/backplane-tools@latest; backplane-tools install all
+```
 
 Follow instructions on screen to add tools to `PATH`.
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ backplane-tools offers an easy solution to install, remove, and upgrade a useful
   - [Upgrade a specific thing](#upgrade-a-specific-thing)
   - [Remove everything](#remove-everything)
   - [Remove a specific thing](#remove-a-specific-thing)
+  - [Cleanup everything](#cleanup-everything)
+  - [Cleanup a specific thing](#cleanup-a-specific-thing)
 - [Design](#design)
   - [Directory Structure](#directory-structure)
   - [Installing](#installing)
   - [Upgrading](#upgrading)
   - [Removing](#removing)
+  - [Cleaning up](#cleaning-up)
 <!-- tocstop -->
 
 ## Tools
@@ -51,8 +54,7 @@ Quick reference guide
 Install backplane-tools with the following command:
 
 ```shell
-go install github.com/openshift/backplane-tools@latest; backplane-tools install all
-```
+go install github.com/openshift/backplane-tools@latest; backplane-tools install all```
 
 Follow instructions on screen to add tools to `PATH`.
 
@@ -155,6 +157,16 @@ backplane-tools remove all
 backplane-tools remove <tool name>
 ```
 
+### Cleanup everything
+```shell
+backplane-tools cleanup all
+```
+
+### Cleanup a specific thing
+```shell
+backplane-tools cleanup <tool name>
+```
+
 ## Design
 
 backplane-tools strives to be simplistic and non-invasive; it should not conflict with currently installed programs, nor should it require extensive research before operating.
@@ -215,3 +227,10 @@ Users are able to remove individual tools or completely remove all files and dat
 `backplane-tools remove <toolA> <toolB> ...` allows users to remove a specific set of tools from their system. This is done by removing the tool-specific directory at `$HOME/.local/bin/backplane/<tool name>`, as well as the tool's linked executable in `$HOME/.local/bin/backplane/latest/`.
 
 `backplane-tools remove all` allows users to remove everything managed by backplane-tools. This is done by completely removing `$HOME/.bin/local/backplane/`. Subsequent calls to `backplane-tools install` will cause the directory structure to be recreated from scratch.
+
+### Cleaning up
+Users are able to remove older versions of individual or all tools managed by backplane-tools.
+
+`backplane-tools cleanup <toolA> <toolB> ...` allows users to cleanup older versions of a specific set of tools from their system. This is done by removing the tool-specific directory at `$HOME/.local/bin/backplane/<tool name>/<old_version>`, keeping only the latest installed version as well as the tool's linked executable in `$HOME/.local/bin/backplane/latest/`.
+
+`backplane-tools cleanup all` allows users to remove older versions of everything managed by backplane-tools. This is done by removing `$HOME/.bin/local/backplane/<tool name>/<old_version>`.

--- a/cmd/cleanup/cleanup.go
+++ b/cmd/cleanup/cleanup.go
@@ -1,0 +1,61 @@
+package cleanup
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/backplane-tools/pkg/tools"
+	"github.com/openshift/backplane-tools/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+// Cmd returns the Command used to invoke the upgrade logic
+func Cmd() *cobra.Command {
+	toolNames := tools.Names()
+	cleanupCmd := &cobra.Command{
+		Use:       fmt.Sprintf("cleanup [all|%s]", strings.Join(toolNames, "|")),
+		Aliases:   []string{"clean-up"},
+		Args:      cobra.OnlyValidArgs,
+		ValidArgs: append(toolNames, "all"),
+		Short:     "Cleans up older versions of existing tool",
+		Long:      "Cleans up older versions and keeps only the latest installed version of one or more tools from the provided list. It's valid to specify multiple tools: in this case, all tools provided will be cleaned up. If no specific tools are provided, all are cleaned up by default.",
+		RunE: func(_ *cobra.Command, args []string) error {
+			return Cleanup(args)
+		},
+	}
+	return cleanupCmd
+}
+
+// run cleanup the tool(s) specified by the provided positional args
+func Cleanup(args []string) error {
+	var listTools []tools.Tool
+	if len(args) == 0 || utils.Contains(args, "all") {
+		// If user explicitly passes 'all' or doesn't specify which tools to clean up,
+		// everything that's been installed locally will be cleaned up
+		var err error
+		listTools, err = tools.ListInstalled()
+		if err != nil {
+			return err
+		}
+	} else {
+		// otherwise build the list verifying tool exist
+		toolMap := tools.GetMap()
+
+		listTools = []tools.Tool{}
+		for _, toolName := range args {
+			t, found := toolMap[toolName]
+			if !found {
+				return fmt.Errorf("failed to locate '%s' in list of supported tools", toolName)
+			}
+			listTools = append(listTools, t)
+		}
+	}
+
+	fmt.Println("Cleaning up the following tools: ")
+
+	err := tools.Cleanup(listTools)
+	if err != nil {
+		return fmt.Errorf("failed to clean up tools: %w", err)
+	}
+	return nil
+}

--- a/cmd/cleanup/cleanup.go
+++ b/cmd/cleanup/cleanup.go
@@ -26,7 +26,7 @@ func Cmd() *cobra.Command {
 	return cleanupCmd
 }
 
-// run cleanup the tool(s) specified by the provided positional args
+// Cleanup cleans up older versions of the tool(s) specified by the provided positional args
 func Cleanup(args []string) error {
 	var listTools []tools.Tool
 	if len(args) == 0 || utils.Contains(args, "all") {

--- a/cmd/cleanup/cleanup.go
+++ b/cmd/cleanup/cleanup.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Cmd returns the Command used to invoke the upgrade logic
+// Cmd returns the Command used to invoke the cleanup logic
 func Cmd() *cobra.Command {
 	toolNames := tools.Names()
 	cleanupCmd := &cobra.Command{

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 
+	"github.com/openshift/backplane-tools/cmd/cleanup"
 	"github.com/openshift/backplane-tools/cmd/install"
 	"github.com/openshift/backplane-tools/cmd/list"
 	"github.com/openshift/backplane-tools/cmd/remove"
@@ -27,6 +28,7 @@ func init() {
 	cmd.AddCommand(list.Cmd())
 	cmd.AddCommand(remove.Cmd())
 	cmd.AddCommand(upgrade.Cmd())
+	cmd.AddCommand(cleanup.Cmd())
 }
 
 func main() {

--- a/pkg/tools/base/default.go
+++ b/pkg/tools/base/default.go
@@ -126,3 +126,46 @@ func (t *Default) InstalledVersion() (string, error) {
 	}
 	return t.installedVersion, nil
 }
+
+// Cleanup removes all previous versions of an installed tool except the currently linked version
+func (t *Default) Cleanup() (string, error) {
+	toolDir := t.ToolDir()
+
+	// Get the currently installed version (the one linked in latest/)
+	currentVersion, err := t.InstalledVersion()
+	if err != nil {
+		return "", fmt.Errorf("failed to get installed version: %w", err)
+	}
+
+	// Read all version directories in the tool directory
+	entries, err := os.ReadDir(toolDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to read tool directory %s: %w", toolDir, err)
+	}
+
+	removedVersions := []string{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		// Skip the current version
+		if entry.Name() == currentVersion {
+			continue
+		}
+
+		// Remove old version directory
+		versionPath := filepath.Join(toolDir, entry.Name())
+		err = os.RemoveAll(versionPath)
+		if err != nil {
+			return strings.Join(removedVersions, ", "), fmt.Errorf("failed to remove version %s: %w", entry.Name(), err)
+		}
+		removedVersions = append(removedVersions, entry.Name())
+	}
+
+	if len(removedVersions) == 0 {
+		return "no old versions found", nil
+	}
+
+	return fmt.Sprintf("removed versions: %s", strings.Join(removedVersions, ", ")), nil
+}

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -50,6 +50,9 @@ type Tool interface {
 
 	// LatestVersion gets the latest version available on repo
 	LatestVersion() (string, error)
+
+	// Cleanup removes all previous versions of an installed tool
+	Cleanup() (string, error)
 }
 
 var toolMap map[string]Tool
@@ -201,4 +204,19 @@ func ListInstalled() ([]Tool, error) {
 		}
 	}
 	return installedTools, nil
+}
+
+func Cleanup(tools []Tool) error {
+	for _, tool := range tools {
+		fmt.Println()
+		fmt.Printf("Removing %s\n", tool.Name())
+		msg, err := tool.Cleanup()
+		if err != nil {
+			fmt.Printf("Encountered error while cleaning up %s: %v\n", tool.Name(), err)
+			fmt.Println("Skipping...")
+		} else {
+			fmt.Printf("Successfully cleaned up %s: %s\n", tool.Name(), msg)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
**Problem**
Over time, backplane-tools accumulates multiple versions of each installed tool in ~/.local/bin/backplane/. 
Each upgrade creates a new versioned directory while keeping all previous versions, leading to significant disk usage growth. For users who frequently update tools, this can result in hundreds of megabytes or even gigabytes of redundant binaries.

For example, after several updates, a user might have:
```
~/.local/bin/backplane/oc/
  ├── 4.19.5/
  ├── 4.20.8/
  ├── 4.20.9/
  ├── 4.20.10/
  ├── 4.20.11/
  └── 4.21.0/  (currently linked in latest/)
```
Only the latest version (4.21.0) is actually used, but all previous versions remain on disk.

**Solution**
This PR introduces a new cleanup subcommand that removes all older versions of installed tools while preserving only the currently active version (the one symlinked in latest/).

Usage:
```
# Clean up a specific tool
backplane-tools cleanup oc

# Clean up multiple tools
backplane-tools cleanup oc ocm rosa

# Clean up all installed tools
backplane-tools cleanup all
# or simply
backplane-tools cleanup
```

**Testing**
Manual testing confirmed that the cleanup command successfully removes older versions while preserving the active version and its symlink.
```
$ backplane-tools cleanup
Cleaning up the following tools: 

Removing osdctl
Successfully cleaned up osdctl: removed versions: v0.23.2, v0.23.3, v0.23.4, v0.23.5, v0.24.0

Removing backplane-cli
Successfully cleaned up backplane-cli: removed versions: v0.5.7, v0.5.8, v0.5.9, v0.6.0, v0.6.1

Removing rosa
Successfully cleaned up rosa: removed versions: v1.2.40, v1.2.41, v1.2.42, v1.2.43, v1.2.44

Removing ocm-container
Successfully cleaned up ocm-container: removed versions: v2.0.0, v2.0.1, v2.0.2, v2.0.3, v2.0.4

Removing aws
Successfully cleaned up aws: removed versions: 2.13.0, 2.13.5, 2.14.0, 2.14.5, 2.15.0

Removing ocm
Successfully cleaned up ocm: removed versions: v1.0.6, v1.0.7, v1.0.8, v1.0.9, v1.1.0

Removing ocm-addons
Successfully cleaned up ocm-addons: removed versions: v0.8.2, v0.8.3, v0.8.4, v0.8.5, v0.9.0

Removing yq
Successfully cleaned up yq: removed versions: v4.43.2, v4.43.3, v4.43.4, v4.43.5, v4.44.0

Removing gcloud
Successfully cleaned up gcloud: removed versions: 496.0.0, 497.0.0, 498.0.0, 499.0.0, 500.0.0

Removing backplane-tools
Successfully cleaned up backplane-tools: removed versions: v1.0.0, v1.0.1, v1.0.2, v1.0.3, v1.0.4

Removing oc
Successfully cleaned up oc: no old versions found
```