### PR TITLE
Update .ci-operator.yaml

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.20-openshift-4.14
+  tag: rhel-8-release-golang-1.21-openshift-4.16


### PR DESCRIPTION
Match this to what is in `openshift/release` so I can get https://github.com/openshift/release/pull/78216 rehearsals to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure dependencies to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->