### PR TITLE
feat(self): replace GitHub release install with go install

### DIFF
--- a/pkg/tools/base/gobin.go
+++ b/pkg/tools/base/gobin.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"debug/buildinfo"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -95,7 +96,7 @@ func resolveGOBIN(goBin string) (string, error) {
 	}
 	gopath := strings.TrimSpace(string(out))
 	if gopath == "" {
-		return "", fmt.Errorf("both GOBIN and GOPATH are empty; cannot determine where 'go install' placed the binary")
+		return "", errors.New("both GOBIN and GOPATH are empty; cannot determine where 'go install' placed the binary")
 	}
 	return filepath.Join(gopath, "bin"), nil
 }

--- a/pkg/tools/base/gobin.go
+++ b/pkg/tools/base/gobin.go
@@ -1,0 +1,114 @@
+package base
+
+import (
+	"debug/buildinfo"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/openshift/backplane-tools/pkg/utils"
+)
+
+type GoBin struct {
+	Default
+	Module string
+	Branch string
+}
+
+func (g *GoBin) LatestVersion() (string, error) {
+	return g.Branch, nil
+}
+
+func (g *GoBin) Install() error {
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		return fmt.Errorf("failed to locate 'go' on $PATH: the Go toolchain is required to install %s: %w", g.Name(), err)
+	}
+
+	ref := g.Module + "@" + g.Branch
+	cmd := exec.Command(goBin, "install", ref)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run 'go install %s': %w", ref, err)
+	}
+
+	gobin, err := resolveGOBIN(goBin)
+	if err != nil {
+		return err
+	}
+	builtBinary := filepath.Join(gobin, g.ExecutableName())
+
+	if _, err := os.Stat(builtBinary); err != nil {
+		return fmt.Errorf("expected binary at '%s' after 'go install', but it was not found: %w", builtBinary, err)
+	}
+
+	commitHash, err := extractVCSRevision(builtBinary)
+	if err != nil {
+		return err
+	}
+
+	toolDir := g.ToolDir()
+	versionedDir := filepath.Join(toolDir, commitHash)
+	if err := os.MkdirAll(versionedDir, os.FileMode(0o755)); err != nil {
+		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
+	}
+
+	src, err := os.Open(builtBinary)
+	if err != nil {
+		return fmt.Errorf("failed to open built binary '%s': %w", builtBinary, err)
+	}
+	defer src.Close()
+
+	destPath := filepath.Join(versionedDir, g.ExecutableName())
+	if err := utils.WriteFile(src, destPath, 0o755); err != nil {
+		return fmt.Errorf("failed to copy binary to '%s': %w", destPath, err)
+	}
+
+	latestFilePath := g.SymlinkPath()
+	if err := os.Remove(latestFilePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove existing '%s' symlink at '%s': %w", g.ExecutableName(), LatestDir, err)
+	}
+
+	if err := os.Symlink(destPath, latestFilePath); err != nil {
+		return fmt.Errorf("failed to link new '%s' binary to '%s': %w", g.ExecutableName(), LatestDir, err)
+	}
+
+	return nil
+}
+
+func resolveGOBIN(goBin string) (string, error) {
+	out, err := exec.Command(goBin, "env", "GOBIN").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to run 'go env GOBIN': %w", err)
+	}
+	gobin := strings.TrimSpace(string(out))
+	if gobin != "" {
+		return gobin, nil
+	}
+
+	out, err = exec.Command(goBin, "env", "GOPATH").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to run 'go env GOPATH': %w", err)
+	}
+	gopath := strings.TrimSpace(string(out))
+	if gopath == "" {
+		return "", fmt.Errorf("both GOBIN and GOPATH are empty; cannot determine where 'go install' placed the binary")
+	}
+	return filepath.Join(gopath, "bin"), nil
+}
+
+func extractVCSRevision(binaryPath string) (string, error) {
+	info, err := buildinfo.ReadFile(binaryPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read build info from '%s': %w", binaryPath, err)
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			return setting.Value, nil
+		}
+	}
+	return "", fmt.Errorf("vcs.revision not found in build info of '%s'", binaryPath)
+}

--- a/pkg/tools/base/gobin.go
+++ b/pkg/tools/base/gobin.go
@@ -95,10 +95,11 @@ func resolveGOBIN(goBin string) (string, error) {
 		return "", fmt.Errorf("failed to run 'go env GOPATH': %w", err)
 	}
 	gopath := strings.TrimSpace(string(out))
-	if gopath == "" {
+	entries := filepath.SplitList(gopath)
+	if len(entries) == 0 || entries[0] == "" {
 		return "", errors.New("both GOBIN and GOPATH are empty; cannot determine where 'go install' placed the binary")
 	}
-	return filepath.Join(gopath, "bin"), nil
+	return filepath.Join(entries[0], "bin"), nil
 }
 
 func extractModuleVersion(binaryPath, module string) (string, error) {

--- a/pkg/tools/base/gobin.go
+++ b/pkg/tools/base/gobin.go
@@ -45,13 +45,13 @@ func (g *GoBin) Install() error {
 		return fmt.Errorf("expected binary at '%s' after 'go install', but it was not found: %w", builtBinary, err)
 	}
 
-	commitHash, err := extractVCSRevision(builtBinary)
+	version, err := extractModuleVersion(builtBinary, g.Module)
 	if err != nil {
 		return err
 	}
 
 	toolDir := g.ToolDir()
-	versionedDir := filepath.Join(toolDir, commitHash)
+	versionedDir := filepath.Join(toolDir, version)
 	if err := os.MkdirAll(versionedDir, os.FileMode(0o755)); err != nil {
 		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
 	}
@@ -100,15 +100,13 @@ func resolveGOBIN(goBin string) (string, error) {
 	return filepath.Join(gopath, "bin"), nil
 }
 
-func extractVCSRevision(binaryPath string) (string, error) {
+func extractModuleVersion(binaryPath, module string) (string, error) {
 	info, err := buildinfo.ReadFile(binaryPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read build info from '%s': %w", binaryPath, err)
 	}
-	for _, setting := range info.Settings {
-		if setting.Key == "vcs.revision" {
-			return setting.Value, nil
-		}
+	if info.Main.Path == module {
+		return info.Main.Version, nil
 	}
-	return "", fmt.Errorf("vcs.revision not found in build info of '%s'", binaryPath)
+	return "", fmt.Errorf("module '%s' not found in build info of '%s'", module, binaryPath)
 }

--- a/pkg/tools/self/self.go
+++ b/pkg/tools/self/self.go
@@ -1,104 +1,19 @@
 package self
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
-	gogithub "github.com/google/go-github/v51/github"
-	"github.com/openshift/backplane-tools/pkg/sources/github"
 	"github.com/openshift/backplane-tools/pkg/tools/base"
-	"github.com/openshift/backplane-tools/pkg/utils"
 )
 
-// Tool implements the interface to manage the 'backplane-tools' binary
 type Tool struct {
-	base.Github
+	base.GoBin
 }
 
 func New() *Tool {
-	t := &Tool{
-		Github: base.Github{
+	return &Tool{
+		GoBin: base.GoBin{
 			Default: base.NewDefault("backplane-tools"),
-			Source:  github.NewSource("openshift", "backplane-tools"),
+			Module:  "github.com/openshift/backplane-tools",
+			Branch:  "main",
 		},
 	}
-	return t
-}
-
-func (t *Tool) Install() error {
-	// Pull latest release from GH
-	release, err := t.Source.FetchLatestRelease()
-	if err != nil {
-		return err
-	}
-
-	matches := github.FindAssetsForArchAndOS(release.Assets)
-	if len(matches) != 1 {
-		return fmt.Errorf("unexpected number of assets found matching system spec: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
-	}
-	toolArchiveAsset := matches[0]
-
-	matches = github.FindAssetsContaining([]string{"checksums.txt"}, release.Assets)
-	if len(matches) != 1 {
-		return fmt.Errorf("unexpected number of checksum assets found: expected 1, got %d.\nMatching assets: %v", len(matches), matches)
-	}
-	checksumAsset := matches[0]
-
-	// Download the arch- & os-specific assets
-	toolDir := t.ToolDir()
-	versionedDir := filepath.Join(toolDir, release.GetTagName())
-	err = os.MkdirAll(versionedDir, os.FileMode(0o755))
-	if err != nil {
-		return fmt.Errorf("failed to create version-specific directory '%s': %w", versionedDir, err)
-	}
-
-	err = t.Source.DownloadReleaseAssets([]*gogithub.ReleaseAsset{checksumAsset, toolArchiveAsset}, versionedDir)
-	if err != nil {
-		return fmt.Errorf("failed to download one or more assets: %w", err)
-	}
-
-	// Verify checksum of downloaded assets
-	toolArchiveFilepath := filepath.Join(versionedDir, toolArchiveAsset.GetName())
-	binarySum, err := utils.Sha256sum(toolArchiveFilepath)
-	if err != nil {
-		return fmt.Errorf("failed to calculate checksum for '%s': %w", toolArchiveFilepath, err)
-	}
-
-	checksumFilePath := filepath.Join(versionedDir, checksumAsset.GetName())
-	checksumLine, err := utils.GetLineInFileMatchingKey(checksumFilePath, toolArchiveAsset.GetName())
-	if err != nil {
-		return fmt.Errorf("failed to retrieve checksum from file '%s': %w", checksumFilePath, err)
-	}
-	checksumTokens := strings.Fields(checksumLine)
-	if len(checksumTokens) != 2 {
-		return fmt.Errorf("the checksum file '%s' is invalid: expected 2 fields, got %d", checksumFilePath, len(checksumTokens))
-	}
-	actual := checksumTokens[0]
-
-	toolExecutable := t.ExecutableName()
-	if strings.TrimSpace(binarySum) != strings.TrimSpace(actual) {
-		return fmt.Errorf("warning: Checksum for '%s' does not match the calculated value. Please retry installation. If issue persists, this tool can be downloaded manually at %s", toolExecutable, toolArchiveAsset.GetBrowserDownloadURL())
-	}
-
-	// Untar binary bundle
-	err = utils.Unarchive(toolArchiveFilepath, versionedDir)
-	if err != nil {
-		return fmt.Errorf("failed to unarchive the '%s' asset file '%s': %w", toolExecutable, toolArchiveFilepath, err)
-	}
-
-	// Link as latest
-	latestFilePath := t.SymlinkPath()
-	err = os.Remove(latestFilePath)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove existing '%s' binary at '%s': %w", toolExecutable, base.LatestDir, err)
-	}
-
-	toolBinaryFilepath := filepath.Join(versionedDir, toolExecutable)
-	err = os.Symlink(toolBinaryFilepath, latestFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to link new '%s' binary to '%s': %w", toolExecutable, base.LatestDir, err)
-	}
-	return nil
 }


### PR DESCRIPTION
## Summary

- Replace the GitHub release-based self-install with `go install github.com/openshift/backplane-tools@main`
- Add a new `base.GoBin` base type that handles the full install flow: `go install`, GOBIN resolution, commit hash extraction from binary build info, copy to backplane directory, and symlink
- Self tool (`pkg/tools/self/self.go`) is now a minimal constructor embedding `base.GoBin`

**Motivation:** Maintainers aren't regularly creating GitHub releases, making self-updates via release assets unreliable. `go install` from main always reflects the latest source.

**How it works:**
- `Install()` runs `go install ...@main`, copies the binary from GOBIN into `~/.local/bin/backplane/backplane-tools/<commit-hash>/`, and symlinks to `latest/`
- Version is the git commit hash extracted from the binary's embedded build info (`vcs.revision`) via `debug/buildinfo`
- `LatestVersion()` returns `"main"` (never matches a commit hash), so upgrades always re-run `go install`
- Requires Go on PATH; fails with a clear error if missing

## Test plan

- [ ] `go vet ./...` and `go build ./...` pass
- [ ] `backplane-tools install backplane-tools` installs via `go install` and creates the expected directory structure
- [ ] `backplane-tools list installed` shows the commit hash as the installed version
- [ ] `backplane-tools upgrade backplane-tools` always re-installs from main
- [ ] Without `go` on PATH, a clear error is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Go-based installer that builds Go modules, verifies embedded build metadata, installs binaries into versioned directories, and maintains a “latest” pointer.

* **Refactor**
  * The self tool now uses the new Go-based installer; prior release/download-based installation logic was removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->